### PR TITLE
refactor!: v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,132 +1,106 @@
 # go-gitcfg
 
-A Go library for reading and working with Git configuration files. Supports both global and repository-specific configurations.
+`go-gitcfg` is a small Go library for reading Git configuration files.
+
+It uses a pure Go parser by default, preserves repeated keys, follows Git configuration precedence and supports `include.path` plus common `includeIf` conditions.
+
+## Install
+
+```sh
+go get github.com/unkn0wn-root/gitcfg
+```
 
 ## Quick Start
-
-### Load Global Configuration
 
 ```go
 package main
 
 import (
-    "fmt"
-    "github.com/unkn0wn-root/go-gitcfg"
+	"context"
+	"fmt"
+
+	"github.com/unkn0wn-root/gitcfg"
 )
 
 func main() {
-    // Load global Git configuration
-    config, err := gitcfg.LoadGlobal()
-    if err != nil {
-        panic(err)
-    }
+	cfg, err := gitcfg.LoadGlobal(context.Background())
+	if err != nil {
+		panic(err)
+	}
 
-    // Get user information
-    user, err := config.GetUser()
-    if err != nil {
-        panic(err)
-    }
+	user, err := cfg.User()
+	if err != nil {
+		panic(err)
+	}
 
-    fmt.Printf("User: %s <%s>\n", user.Name, user.Email)
+	fmt.Printf("%s <%s>\n", user.Name, user.Email)
 }
 ```
 
-### Type-Safe Value Access
+## Loading
 
 ```go
-// Generic type-safe access
-name, err := gitcfg.Get[string](config, "user.name")
-editor, err := gitcfg.Get[string](config, "core.editor")
-autocrlf, err := gitcfg.Get[bool](config, "core.autocrlf")
-filemode, err := gitcfg.Get[bool](config, "core.filemode")
-timeout, err := gitcfg.Get[int](config, "http.timeout")
+ctx := context.Background()
 
-// With default values
-timeout := gitcfg.GetWithDefault[int](config, "http.timeout", 30)
-editor := gitcfg.GetWithDefault[string](config, "core.editor", "vim")
-```
+// Global configuration only. This is also the default for Load.
+cfg, err := gitcfg.LoadGlobal(ctx)
 
-### Load Different Configuration Sources
+// Local repository configuration only.
+cfg, err = gitcfg.LoadLocal(ctx, "/path/to/repo")
 
-```go
-// Load only global configuration
-config, err := gitcfg.LoadGlobal()
+// System, global, local, and worktree scopes in Git precedence order.
+cfg, err = gitcfg.LoadAll(ctx, "/path/to/repo")
 
-// Load only local repository configuration
-config, err := gitcfg.LoadLocal("/path/to/repo")
-
-// Load all configuration sources in precedence order
-config, err := gitcfg.LoadAll("/path/to/repo")
-
-// Load with specific options
-config, err := gitcfg.Load(
-    gitcfg.WithGlobal(),
-    gitcfg.WithLocal(),
-    gitcfg.WithRepoPath("/path/to/repo"),
+// Explicit scopes and options.
+cfg, err = gitcfg.Load(
+	ctx,
+	gitcfg.WithScopes(gitcfg.ScopeGlobal, gitcfg.ScopeLocal),
+	gitcfg.WithRepoPath("/path/to/repo"),
+	gitcfg.WithIncludes(true),
 )
+
+// Optional: use `git config` instead of the pure-Go parser.
+cfg, err = gitcfg.Load(ctx, gitcfg.WithGitCommand())
 ```
 
-### Structured Config Access
+## Accessing Values
 
 ```go
-// User configuration
-user, err := config.GetUser()
-fmt.Printf("Name: %s, Email: %s\n", user.Name, user.Email)
+name, err := gitcfg.Get[string](cfg, "user.name")
+autocrlf, err := gitcfg.Get[bool](cfg, "core.autocrlf")
+timeout := gitcfg.GetDefault[int](cfg, "http.timeout", 30)
 
-// Remote URL (simplified access)
-remoteURL, err := config.GetRemoteURL("origin")
-fmt.Printf("URL: %s\n", remoteURL)
+editor, err := cfg.Value("core.editor")
+editors := cfg.Values("core.editor") // all repeated values, in parse order
+entries := cfg.Entries("remote.origin.fetch")
 
-// Direct section access for complex configurations
-remoteSection := config.GetSection("remote.origin")
-for key, value := range remoteSection {
-    fmt.Printf("%s = %s\n", key, value)
-}
+remoteURL, err := cfg.RemoteURL("origin")
+user, err := cfg.User()
 ```
 
-### Working with Sections and Keys
+Simple getters return the last value. Use `Values` or `Entries` when you need every occurrence of a repeated key.
+
+## Sections And Sources
 
 ```go
-// Check if key exists
-if config.Has("user.name") {
-    fmt.Println("User name is configured")
+if cfg.Has("user.email") {
+	fmt.Println("email configured")
 }
 
-// Get all sections
-sections := config.GetSections()
-fmt.Printf("Found sections: %v\n", sections)
-
-// Get entire section as map
-userSection := config.GetSection("user")
-for key, value := range userSection {
-    fmt.Printf("%s = %s\n", key, value)
+for _, section := range cfg.Sections() {
+	fmt.Println(section)
 }
 
-// Check if section exists
-if config.HasSection("user") {
-    fmt.Println("User section exists")
-}
+remote := cfg.Section("remote.origin")
+all := cfg.All()
+sources := cfg.Sources()
 ```
 
-### With context
+## Supported Scopes
 
-```go
-import "context"
+- `ScopeSystem`: `/etc/gitconfig` and common system fallback paths
+- `ScopeGlobal`: XDG global config and `~/.gitconfig`
+- `ScopeLocal`: `.git/config`
+- `ScopeWorktree`: `.git/config.worktree`
 
-ctx := context.WithTimeout(context.Background(), 30*time.Second)
-
-// Load with context
-config, err := gitcfg.LoadWithContext(ctx, gogitcfg.WithGlobal())
-
-// Reload with context
-err = config.ReloadWithContext(ctx)
-```
-
-## Configuration Sources
-
-The library supports all standard Git configuration sources:
-
-- **System**: `/etc/gitconfig` (system-wide)
-- **Global**: `~/.gitconfig` (user-specific)
-- **Local**: `.git/config` (repository-specific)
-- **Worktree**: `.git/config.worktree` (worktree-specific)
+Environment overrides such as `GIT_CONFIG_GLOBAL`, `GIT_CONFIG_SYSTEM` and `GIT_CONFIG_NOSYSTEM` are respected.

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,3 @@
+// Package gitcfg reads Git configuration files with Git like precedence,
+// includes, conditional includes and typed value access.
+package gitcfg

--- a/errors.go
+++ b/errors.go
@@ -7,12 +7,19 @@ import (
 )
 
 var (
-	ErrKeyNotFound      = errors.New("key not found")
-	ErrSectionNotFound  = errors.New("section not found")
+	// ErrKeyNotFound means the requested key is not present.
+	ErrKeyNotFound = errors.New("key not found")
+	// ErrSectionNotFound means the requested section is not present.
+	ErrSectionNotFound = errors.New("section not found")
+	// ErrInvalidKeyFormat means a key cannot be parsed as Git config syntax.
 	ErrInvalidKeyFormat = errors.New("invalid key format")
-	ErrInvalidValue     = errors.New("invalid value")
+	// ErrInvalidValue means a value cannot be converted or parsed.
+	ErrInvalidValue = errors.New("invalid value")
+	// ErrIncludeCycle means config includes recursively reference each other.
+	ErrIncludeCycle = errors.New("include cycle")
 )
 
+// ConfigError adds operation, key, section and source context to errors.
 type ConfigError struct {
 	Op      string
 	Key     string
@@ -22,7 +29,10 @@ type ConfigError struct {
 }
 
 func (e *ConfigError) Error() string {
-	parts := []string{"gitconfig:", e.Op}
+	parts := []string{"gitcfg:"}
+	if e.Op != "" {
+		parts = append(parts, e.Op)
+	}
 
 	if e.Section != "" && e.Key != "" {
 		parts = append(parts, fmt.Sprintf("%s.%s", e.Section, e.Key))
@@ -34,19 +44,12 @@ func (e *ConfigError) Error() string {
 		parts = append(parts, fmt.Sprintf("(source: %s)", e.Source))
 	}
 
-	parts = append(parts, e.Err.Error())
+	if e.Err != nil {
+		parts = append(parts, e.Err.Error())
+	}
 	return strings.Join(parts, " ")
 }
 
 func (e *ConfigError) Unwrap() error {
 	return e.Err
 }
-
-func (e *ConfigError) Is(target error) bool {
-	var targetErr *ConfigError
-	if !errors.As(target, &targetErr) {
-		return false
-	}
-	return e.Op == targetErr.Op && e.Key == targetErr.Key && e.Section == targetErr.Section
-}
-

--- a/gitcfg.go
+++ b/gitcfg.go
@@ -3,340 +3,483 @@ package gitcfg
 import (
 	"context"
 	"fmt"
+	"slices"
+	"sort"
+	"strconv"
 	"strings"
-	"sync"
+	"sync/atomic"
 )
+
+// Scope identifies a Git configuration scope.
+type Scope int
 
 const (
-	// System-wide Git configuration (/etc/gitconfig).
-	SourceTypeSystem ConfigSourceType = iota
-	// User-specific Git configuration (~/.gitconfig).
-	SourceTypeGlobal
-	// Repository-specific Git configuration (.git/config).
-	SourceTypeLocal
-	// Worktree-specific Git configuration (.git/config.worktree).
-	SourceTypeWorktree
+	// ScopeSystem is the system-wide Git configuration.
+	ScopeSystem Scope = iota
+	// ScopeGlobal is the user-level Git configuration.
+	ScopeGlobal
+	// ScopeLocal is the repository-local Git configuration.
+	ScopeLocal
+	// ScopeWorktree is the worktree-specific Git configuration.
+	ScopeWorktree
 )
 
-type Constraint interface {
-	~string | ~int | ~int8 | ~int16 | ~int32 | ~int64 |
-		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
-		~float32 | ~float64 | ~bool
-}
-
-type User struct {
-	Name  string
-	Email string
-}
-
-type ConfigSource struct {
-	Type ConfigSourceType
-	Path string
-}
-
-type ConfigSourceType int
-
-func (t ConfigSourceType) String() string {
-	switch t {
-	case SourceTypeSystem:
+func (s Scope) String() string {
+	switch s {
+	case ScopeSystem:
 		return "system"
-	case SourceTypeGlobal:
+	case ScopeGlobal:
 		return "global"
-	case SourceTypeLocal:
+	case ScopeLocal:
 		return "local"
-	case SourceTypeWorktree:
+	case ScopeWorktree:
 		return "worktree"
 	default:
 		return "unknown"
 	}
 }
 
-type Config struct {
-	mu       sync.RWMutex
-	sections map[string]map[string]string
-	sources  []ConfigSource
+// Source describes a configuration file that contributed entries.
+type Source struct {
+	Scope Scope
+	Path  string
 }
 
-func (c *Config) String() string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
+// Entry is one raw Git configuration key value entry.
+type Entry struct {
+	Key     string
+	Section string
+	Name    string
+	Value   string
+	Source  Source
+	Line    int
+}
 
-	var sb strings.Builder
+// User is the structured user.name and user.email.
+type User struct {
+	Name  string
+	Email string
+}
 
-	if len(c.sources) > 0 {
-		sb.WriteString("# Configuration sources:\n")
-		for _, source := range c.sources {
-			sb.WriteString(fmt.Sprintf("# %s: %s\n", source.Type, source.Path))
-		}
-		sb.WriteString("\n")
+type configState struct {
+	entries  map[string][]Entry
+	sources  []Source
+	roots    []Source
+	repoPath string
+	includes bool
+	useGit   bool
+}
+
+// Config stores parsed Git configuration entries.
+// Repeated keys are preserved. Simple accessors return last value.
+// Reload atomically replaces the underlying snapshot.
+type Config struct {
+	state atomic.Pointer[configState]
+}
+
+func newConfig() *Config {
+	config := &Config{}
+	config.state.Store(&configState{entries: make(map[string][]Entry)})
+	return config
+}
+
+func (c *Config) snapshot() *configState {
+	if c == nil {
+		return &configState{}
 	}
-
-	for section, sectionMap := range c.sections {
-		sb.WriteString(fmt.Sprintf("[%s]\n", section))
-		for key, value := range sectionMap {
-			// Quote values that contain spaces or special characters
-			if strings.ContainsAny(value, " \t\n\r\"\\") {
-				sb.WriteString(fmt.Sprintf("  %s = %q\n", key, value))
-			} else {
-				sb.WriteString(fmt.Sprintf("  %s = %s\n", key, value))
-			}
-		}
-		sb.WriteString("\n")
+	state := c.state.Load()
+	if state == nil {
+		return &configState{}
 	}
+	return state
+}
 
-	return sb.String()
+func (c *Config) mutableState() *configState {
+	state := c.state.Load()
+	if state == nil {
+		state = &configState{entries: make(map[string][]Entry)}
+		c.state.Store(state)
+	}
+	if state.entries == nil {
+		state.entries = make(map[string][]Entry)
+	}
+	return state
 }
 
 func (c *Config) Has(key string) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	parts := strings.SplitN(key, ".", 2)
-	if len(parts) != 2 {
-		return false
-	}
-
-	section, subkey := parts[0], parts[1]
-
-	sectionMap, exists := c.sections[section]
-	if !exists {
-		return false
-	}
-
-	_, exists = sectionMap[subkey]
-	return exists
+	_, ok := lastEntry(c.snapshot(), key)
+	return ok
 }
 
-func (c *Config) GetSection(section string) map[string]string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	sectionMap, exists := c.sections[section]
-	if !exists {
-		return make(map[string]string)
-	}
-
-	result := make(map[string]string, len(sectionMap))
-	for k, v := range sectionMap {
-		result[k] = v
-	}
-	return result
-}
-
-func (c *Config) GetSections() []string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	sections := make([]string, 0, len(c.sections))
-	for section := range c.sections {
-		sections = append(sections, section)
-	}
-	return sections
-}
-
-func (c *Config) HasSection(section string) bool {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	_, exists := c.sections[section]
-	return exists
-}
-
-
-func (c *Config) GetAll() map[string]map[string]string {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	result := make(map[string]map[string]string, len(c.sections))
-	for section, sectionMap := range c.sections {
-		result[section] = make(map[string]string, len(sectionMap))
-		for k, v := range sectionMap {
-			result[section][k] = v
+// Value returns the effective value for key.
+// If the key appears more than once, Value returns the last value in Git
+// precedence/order.
+func (c *Config) Value(key string) (string, error) {
+	state := c.snapshot()
+	entry, ok := lastEntry(state, key)
+	if !ok {
+		section, name, _ := splitConfigKey(key)
+		if section == "" {
+			return "", &ConfigError{Op: "get", Key: key, Err: ErrInvalidKeyFormat}
 		}
+		if !hasSection(state, section) {
+			return "", &ConfigError{Op: "get", Section: section, Key: name, Err: ErrSectionNotFound}
+		}
+		return "", &ConfigError{Op: "get", Section: section, Key: name, Err: ErrKeyNotFound}
 	}
-	return result
+	return entry.Value, nil
 }
 
-func (c *Config) GetSources() []ConfigSource {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	sources := make([]ConfigSource, len(c.sources))
-	copy(sources, c.sources)
-	return sources
-}
-
-func (c *Config) Reload() error {
-	return c.ReloadWithContext(context.Background())
-}
-
-func (c *Config) ReloadWithContext(ctx context.Context) error {
-	c.mu.Lock()
-	sources := make([]ConfigSource, len(c.sources))
-	copy(sources, c.sources)
-	c.mu.Unlock()
-
-	if len(sources) == 0 {
+// Values returns all values for key in parse order.
+func (c *Config) Values(key string) []string {
+	normalized, err := normalizeKey(key)
+	if err != nil {
 		return nil
 	}
 
-	newConfig := &Config{
-		sections: make(map[string]map[string]string),
-		sources:  make([]ConfigSource, 0, len(sources)),
+	entries := c.snapshot().entries[normalized]
+	values := make([]string, len(entries))
+	for i, entry := range entries {
+		values[i] = entry.Value
+	}
+	return values
+}
+
+// Entries returns all raw entries for key in parse order.
+func (c *Config) Entries(key string) []Entry {
+	normalized, err := normalizeKey(key)
+	if err != nil {
+		return nil
 	}
 
-	parser := newParser()
-	for _, source := range sources {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-		}
+	entries := c.snapshot().entries[normalized]
+	result := make([]Entry, len(entries))
+	copy(result, entries)
+	return result
+}
 
-		if err := parser.parseConfigFile(source.Path, newConfig); err != nil {
-			return fmt.Errorf("failed to reload from %s: %w", source.Path, err)
+// Section returns the effective key-value map for section.
+func (c *Config) Section(section string) map[string]string {
+	section = strings.ToLower(strings.TrimSpace(section))
+	result := make(map[string]string)
+
+	for _, entries := range c.snapshot().entries {
+		if len(entries) == 0 {
+			continue
 		}
-		newConfig.sources = append(newConfig.sources, source)
+		entry := entries[len(entries)-1]
+		if entry.Section == section {
+			result[entry.Name] = entry.Value
+		}
+	}
+	return result
+}
+
+// HasSection reports whether section has any effective keys.
+func (c *Config) HasSection(section string) bool {
+	return len(c.Section(section)) > 0
+}
+
+// Sections returns all sections in deterministic order.
+func (c *Config) Sections() []string {
+	seen := make(map[string]struct{})
+	for _, entries := range c.snapshot().entries {
+		if len(entries) == 0 {
+			continue
+		}
+		seen[entries[len(entries)-1].Section] = struct{}{}
 	}
 
-	c.mu.Lock()
-	c.sections = newConfig.sections
-	c.sources = newConfig.sources
-	c.mu.Unlock()
+	sections := make([]string, 0, len(seen))
+	for section := range seen {
+		sections = append(sections, section)
+	}
+	sort.Strings(sections)
+	return sections
+}
 
+// All returns the effective configuration grouped by section.
+func (c *Config) All() map[string]map[string]string {
+	return allValues(c.snapshot())
+}
+
+// Sources returns the configuration sources that were read.
+func (c *Config) Sources() []Source {
+	return cloneSources(c.snapshot().sources)
+}
+
+// Reload reloads the original root sources into c.
+func (c *Config) Reload(ctx context.Context) error {
+	state := c.snapshot()
+	roots := state.roots
+
+	if len(roots) == 0 {
+		return nil
+	}
+
+	parser := newParser(parserOptions{includeFiles: state.includes, repoPath: state.repoPath})
+	var next *Config
+	if state.useGit {
+		var err error
+		next, err = parser.parseFromGitCommand(ctx, options{
+			scopes:       scopesFromSources(roots),
+			repoPath:     state.repoPath,
+			includeFiles: state.includes,
+			useGit:       true,
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		next = newConfig()
+		nextState := next.mutableState()
+		nextState.roots = append(nextState.roots, roots...)
+		nextState.repoPath = state.repoPath
+		nextState.includes = state.includes
+		parseState := newParseState()
+		for _, source := range roots {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			if err := parser.parseConfigFile(
+				ctx,
+				source.Path,
+				source,
+				next,
+				parseState,
+			); err != nil {
+				return err
+			}
+		}
+	}
+
+	c.state.Store(next.snapshot())
 	return nil
 }
 
+// Clone returns a deep copy.
 func (c *Config) Clone() *Config {
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	clone := &Config{
-		sections: make(map[string]map[string]string, len(c.sections)),
-		sources:  make([]ConfigSource, len(c.sources)),
-	}
-
-	// deep copy
-	for section, sectionMap := range c.sections {
-		clone.sections[section] = make(map[string]string, len(sectionMap))
-		for k, v := range sectionMap {
-			clone.sections[section][k] = v
-		}
-	}
-
-	copy(clone.sources, c.sources)
-
+	clone := &Config{}
+	clone.state.Store(cloneState(c.snapshot()))
 	return clone
 }
 
-
-func (c *Config) GetUser() (*User, error) {
+// User returns user.name and user.email as a User.
+func (c *Config) User() (User, error) {
 	name, err := Get[string](c, "user.name")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get user.name: %w", err)
+		return User{}, fmt.Errorf("get user.name: %w", err)
 	}
 
 	email, err := Get[string](c, "user.email")
 	if err != nil {
-		return nil, fmt.Errorf("failed to get user.email: %w", err)
+		return User{}, fmt.Errorf("get user.email: %w", err)
 	}
 
-	return &User{
-		Name:  name,
-		Email: email,
-	}, nil
+	return User{Name: name, Email: email}, nil
 }
 
-
-func (c *Config) GetRemoteURL(remote string) (string, error) {
+// RemoteURL returns the URL for remote, defaulting to origin.
+func (c *Config) RemoteURL(remote string) (string, error) {
 	if remote == "" {
 		remote = "origin"
 	}
-	return Get[string](c, fmt.Sprintf("remote.%s.url", remote))
+	return Get[string](c, "remote."+remote+".url")
 }
 
-func (c *Config) setRawValue(key, value string) error {
-	if !isValidConfigKey(key) {
-		return fmt.Errorf("%w: %s", ErrInvalidKeyFormat, key)
+// String returns a deterministic Git-config-like representation.
+func (c *Config) String() string {
+	state := c.snapshot()
+	all := allValues(state)
+	sections := make([]string, 0, len(all))
+	for section := range all {
+		sections = append(sections, section)
+	}
+	sort.Strings(sections)
+
+	var b strings.Builder
+	if len(state.sources) > 0 {
+		b.WriteString("# Configuration sources:\n")
+		for _, source := range state.sources {
+			b.WriteString("# ")
+			b.WriteString(source.Scope.String())
+			b.WriteString(": ")
+			b.WriteString(source.Path)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
 	}
 
-	section, remaining, err := parseConfigKey(key)
-	if err != nil {
-		return fmt.Errorf("%w: %s", err, key)
+	for _, section := range sections {
+		b.WriteString("[")
+		b.WriteString(section)
+		b.WriteString("]\n")
+
+		keys := make([]string, 0, len(all[section]))
+		for key := range all[section] {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		for _, key := range keys {
+			b.WriteString("  ")
+			b.WriteString(key)
+			b.WriteString(" = ")
+			b.WriteString(formatConfigValue(all[section][key]))
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
 	}
 
-	if !isValidSectionName(section) && !isValidSubsectionName(section) {
-		return fmt.Errorf("%w: invalid section name %s", ErrInvalidKeyFormat, section)
-	}
-	if !isValidKeyName(remaining) {
-		return fmt.Errorf("%w: invalid key name %s", ErrInvalidKeyFormat, remaining)
-	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if c.sections[section] == nil {
-		c.sections[section] = make(map[string]string)
-	}
-
-	c.sections[section][remaining] = value
-	return nil
+	return b.String()
 }
 
-// Retrieve a configuration value with type conversion.
-func Get[T Constraint](c *Config, key string) (T, error) {
+// Get returns key converted to T.
+func Get[T Scalar](c *Config, key string) (T, error) {
 	var zero T
+	if c == nil {
+		return zero, &ConfigError{Op: "get", Key: key, Err: ErrKeyNotFound}
+	}
 
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-
-	section, subkey, err := parseConfigKey(key)
+	value, err := c.Value(key)
 	if err != nil {
-		return zero, &ConfigError{
-			Op:  "get",
-			Key: key,
-			Err: err,
-		}
-	}
-
-	sectionMap, exists := c.sections[section]
-	if !exists {
-		return zero, &ConfigError{
-			Op:      "get",
-			Key:     subkey,
-			Section: section,
-			Err:     ErrSectionNotFound,
-		}
-	}
-
-	value, exists := sectionMap[subkey]
-	if !exists {
-		return zero, &ConfigError{
-			Op:      "get",
-			Key:     subkey,
-			Section: section,
-			Err:     ErrKeyNotFound,
-		}
+		return zero, err
 	}
 
 	converted, err := convertValue[T](value)
 	if err != nil {
-		return zero, &ConfigError{
-			Op:      "get",
-			Key:     subkey,
-			Section: section,
-			Err:     fmt.Errorf("type conversion failed: %w", err),
-		}
+		section, name, _ := splitConfigKey(key)
+		return zero, &ConfigError{Op: "get", Section: section, Key: name, Err: err}
 	}
-
 	return converted, nil
 }
 
-// Retrieve a configuration value with a default
-func GetWithDefault[T Constraint](c *Config, key string, defaultValue T) T {
+// GetDefault returns key converted to T or fallback if key cannot be read.
+func GetDefault[T Scalar](c *Config, key string, fallback T) T {
 	value, err := Get[T](c, key)
 	if err != nil {
-		return defaultValue
+		return fallback
+	}
+	return value
+}
+
+func (c *Config) addEntry(key, value string, source Source, line int) error {
+	section, name, err := splitConfigKey(key)
+	if err != nil {
+		return err
+	}
+
+	section = strings.ToLower(section)
+	name = strings.ToLower(name)
+	key = section + "." + name
+	entry := Entry{
+		Key:     key,
+		Section: section,
+		Name:    name,
+		Value:   value,
+		Source:  source,
+		Line:    line,
+	}
+
+	s := c.mutableState()
+	s.entries[key] = append(s.entries[key], entry)
+	return nil
+}
+
+func (c *Config) addSource(source Source) {
+	s := c.mutableState()
+	if slices.Contains(s.sources, source) {
+		return
+	}
+	s.sources = append(s.sources, source)
+}
+
+func (c *Config) setRoots(roots []Source) {
+	s := c.mutableState()
+	s.roots = append(s.roots[:0], roots...)
+}
+
+func scopesFromSources(sources []Source) []Scope {
+	scopes := make([]Scope, 0, len(sources))
+	seen := make(map[Scope]bool)
+	for _, src := range sources {
+		if seen[src.Scope] {
+			continue
+		}
+		seen[src.Scope] = true
+		scopes = append(scopes, src.Scope)
+	}
+	return scopes
+}
+
+func lastEntry(state *configState, key string) (Entry, bool) {
+	key, err := normalizeKey(key)
+	if err != nil {
+		return Entry{}, false
+	}
+
+	entries := state.entries[key]
+	if len(entries) == 0 {
+		return Entry{}, false
+	}
+	return entries[len(entries)-1], true
+}
+
+func hasSection(state *configState, section string) bool {
+	section = strings.ToLower(strings.TrimSpace(section))
+	for _, entries := range state.entries {
+		if len(entries) == 0 {
+			continue
+		}
+		if entries[len(entries)-1].Section == section {
+			return true
+		}
+	}
+	return false
+}
+
+func allValues(state *configState) map[string]map[string]string {
+	result := make(map[string]map[string]string)
+	for _, entries := range state.entries {
+		if len(entries) == 0 {
+			continue
+		}
+		entry := entries[len(entries)-1]
+		if result[entry.Section] == nil {
+			result[entry.Section] = make(map[string]string)
+		}
+		result[entry.Section][entry.Name] = entry.Value
+	}
+	return result
+}
+
+func cloneState(state *configState) *configState {
+	clone := &configState{
+		entries:  make(map[string][]Entry, len(state.entries)),
+		sources:  cloneSources(state.sources),
+		roots:    cloneSources(state.roots),
+		repoPath: state.repoPath,
+		includes: state.includes,
+		useGit:   state.useGit,
+	}
+	for key, entries := range state.entries {
+		clone.entries[key] = append([]Entry(nil), entries...)
+	}
+	return clone
+}
+
+func cloneSources(sources []Source) []Source {
+	result := make([]Source, len(sources))
+	copy(result, sources)
+	return result
+}
+
+func formatConfigValue(value string) string {
+	if value == "" {
+		return ""
+	}
+	if strings.ContainsAny(value, " \t\n\r\"\\#;") {
+		return strconv.Quote(value)
 	}
 	return value
 }

--- a/gitcfg_test.go
+++ b/gitcfg_test.go
@@ -2,198 +2,307 @@ package gitcfg
 
 import (
 	"context"
+	"errors"
+	"os"
+	"strings"
+	"sync"
 	"testing"
-	"time"
 )
 
-func TestLoad(t *testing.T) {
-	config, err := Load(WithGlobal())
-	if err != nil {
-		t.Fatalf("Load failed: %v", err)
-	}
-	if config == nil {
-		t.Fatal("Config is nil")
-	}
-}
+type customInt int
 
-func TestLoadWithContext(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+func TestConfigAccessors(t *testing.T) {
+	config := newConfig()
+	source := Source{Scope: ScopeGlobal, Path: "/tmp/gitconfig"}
 
-	config, err := LoadWithContext(ctx, WithGlobal())
-	if err != nil {
-		t.Fatalf("LoadWithContext failed: %v", err)
-	}
-	if config == nil {
-		t.Fatal("Config is nil")
-	}
-}
+	mustAddEntry(t, config, "user.name", "Test User", source)
+	mustAddEntry(t, config, "user.email", "test@example.com", source)
+	mustAddEntry(t, config, "core.editor", "vim", source)
+	mustAddEntry(t, config, "core.editor", "nvim", source)
+	mustAddEntry(t, config, "remote.origin.url", "git@example.com:repo.git", source)
 
-func TestLoadGlobal(t *testing.T) {
-	config, err := LoadGlobal()
-	if err != nil {
-		t.Fatalf("LoadGlobal failed: %v", err)
-	}
-	if config == nil {
-		t.Fatal("Config is nil")
-	}
-}
-
-func TestConfigGet(t *testing.T) {
-	config := &Config{
-		sections: map[string]map[string]string{
-			"test": {"key": "value"},
-		},
-	}
-
-	value, err := Get[string](config, "test.key")
+	editor, err := Get[string](config, "core.editor")
 	if err != nil {
 		t.Fatalf("Get failed: %v", err)
 	}
-	if value != "value" {
-		t.Errorf("Expected 'value', got '%s'", value)
+	if editor != "nvim" {
+		t.Fatalf("expected last editor value, got %q", editor)
+	}
+
+	values := config.Values("core.editor")
+	if len(values) != 2 || values[0] != "vim" || values[1] != "nvim" {
+		t.Fatalf("unexpected repeated values: %#v", values)
+	}
+
+	if got := GetDefault[string](config, "core.missing", "fallback"); got != "fallback" {
+		t.Fatalf("expected fallback, got %q", got)
+	}
+
+	mustAddEntry(t, config, "http.timeout", "42", source)
+	timeout, err := Get[customInt](config, "http.timeout")
+	if err != nil {
+		t.Fatalf("Get named scalar failed: %v", err)
+	}
+	if timeout != 42 {
+		t.Fatalf("unexpected named scalar value: %v", timeout)
+	}
+
+	if !config.Has("user.email") {
+		t.Fatal("expected user.email to exist")
+	}
+	if config.Has("user.missing") {
+		t.Fatal("did not expect user.missing to exist")
+	}
+
+	user, err := config.User()
+	if err != nil {
+		t.Fatalf("User failed: %v", err)
+	}
+	if user.Name != "Test User" || user.Email != "test@example.com" {
+		t.Fatalf("unexpected user: %#v", user)
+	}
+
+	remote, err := config.RemoteURL("")
+	if err != nil {
+		t.Fatalf("RemoteURL failed: %v", err)
+	}
+	if remote != "git@example.com:repo.git" {
+		t.Fatalf("unexpected remote URL: %q", remote)
 	}
 }
 
-func TestConfigGetWithDefault(t *testing.T) {
-	config := &Config{
-		sections: map[string]map[string]string{},
+func TestConfigSectionsSourcesCloneAndString(t *testing.T) {
+	config := newConfig()
+	source := Source{Scope: ScopeGlobal, Path: "/tmp/gitconfig"}
+	config.addSource(source)
+	mustAddEntry(t, config, "user.name", "Test User", source)
+	mustAddEntry(t, config, "core.editor", "nvim", source)
+
+	sections := config.Sections()
+	if len(sections) != 2 || sections[0] != "core" || sections[1] != "user" {
+		t.Fatalf("unexpected sections: %#v", sections)
 	}
 
-	value := GetWithDefault[string](config, "nonexistent.key", "default")
-	if value != "default" {
-		t.Errorf("Expected 'default', got '%s'", value)
+	user := config.Section("USER")
+	if user["name"] != "Test User" {
+		t.Fatalf("unexpected user section: %#v", user)
 	}
-}
-
-func TestConfigHas(t *testing.T) {
-	config := &Config{
-		sections: map[string]map[string]string{
-			"test": {"key": "value"},
-		},
-	}
-
-	if !config.Has("test.key") {
-		t.Error("Expected key to exist")
-	}
-	if config.Has("nonexistent.key") {
-		t.Error("Expected key to not exist")
-	}
-}
-
-func TestConfigGetSection(t *testing.T) {
-	config := &Config{
-		sections: map[string]map[string]string{
-			"test": {"key1": "value1", "key2": "value2"},
-		},
-	}
-
-	section := config.GetSection("test")
-	if len(section) != 2 {
-		t.Errorf("Expected 2 keys, got %d", len(section))
-	}
-	if section["key1"] != "value1" {
-		t.Errorf("Expected 'value1', got '%s'", section["key1"])
-	}
-}
-
-func TestConfigGetSections(t *testing.T) {
-	config := &Config{
-		sections: map[string]map[string]string{
-			"test1": {"key": "value"},
-			"test2": {"key": "value"},
-		},
-	}
-
-	sections := config.GetSections()
-	if len(sections) != 2 {
-		t.Errorf("Expected 2 sections, got %d", len(sections))
-	}
-}
-
-func TestConfigString(t *testing.T) {
-	config := &Config{
-		sections: map[string]map[string]string{
-			"test": {"key": "value"},
-		},
-	}
-
-	str := config.String()
-	if str == "" {
-		t.Error("Expected non-empty string representation")
-	}
-}
-
-func TestConfigClone(t *testing.T) {
-	config := &Config{
-		sections: map[string]map[string]string{
-			"test": {"key": "value"},
-		},
+	user["name"] = "mutated"
+	if config.Section("user")["name"] != "Test User" {
+		t.Fatal("Section returned mutable internal state")
 	}
 
 	clone := config.Clone()
-	if clone == nil {
-		t.Fatal("Clone is nil")
-	}
-
-	// Modify original
-	config.sections["test"]["key"] = "modified"
-
-	// Clone should be unchanged
-	if clone.sections["test"]["key"] != "value" {
-		t.Error("Clone was modified when original changed")
-	}
-}
-
-
-func TestConfigGetUser(t *testing.T) {
-	config := &Config{
-		sections: map[string]map[string]string{
-			"user": {"name": "Test User", "email": "test@example.com"},
-		},
-	}
-
-	user, err := config.GetUser()
+	mustAddEntry(t, config, "user.name", "Changed", source)
+	value, err := clone.Value("user.name")
 	if err != nil {
-		t.Fatalf("GetUser failed: %v", err)
+		t.Fatalf("clone Value failed: %v", err)
 	}
-	if user.Name != "Test User" {
-		t.Errorf("Expected 'Test User', got '%s'", user.Name)
+	if value != "Test User" {
+		t.Fatalf("clone changed with original: %q", value)
 	}
-	if user.Email != "test@example.com" {
-		t.Errorf("Expected 'test@example.com', got '%s'", user.Email)
+
+	rendered := config.String()
+	if !strings.Contains(rendered, "# global: /tmp/gitconfig") ||
+		!strings.Contains(rendered, "[core]\n  editor = nvim") ||
+		!strings.Contains(rendered, "[user]\n  name = Changed") {
+		t.Fatalf("unexpected String output:\n%s", rendered)
 	}
 }
 
-func TestConfigError(t *testing.T) {
-	err := &ConfigError{
-		Op:      "test",
-		Key:     "test.key",
-		Section: "test",
-		Source:  "test.config",
-		Err:     ErrKeyNotFound,
+func TestTypedGetErrors(t *testing.T) {
+	config := newConfig()
+	source := Source{Scope: ScopeGlobal, Path: "/tmp/gitconfig"}
+	mustAddEntry(t, config, "core.autocrlf", "maybe", source)
+
+	_, err := Get[bool](config, "core.autocrlf")
+	if !errors.Is(err, ErrInvalidValue) {
+		t.Fatalf("expected ErrInvalidValue, got %v", err)
 	}
 
-	errStr := err.Error()
-	if errStr == "" {
-		t.Error("Expected non-empty error string")
+	_, err = Get[string](config, "invalid")
+	if !errors.Is(err, ErrInvalidKeyFormat) {
+		t.Fatalf("expected ErrInvalidKeyFormat, got %v", err)
+	}
+
+	_, err = Get[string](config, "core.missing")
+	if !errors.Is(err, ErrKeyNotFound) {
+		t.Fatalf("expected ErrKeyNotFound, got %v", err)
+	}
+
+	_, err = Get[string](config, "user.name")
+	if !errors.Is(err, ErrSectionNotFound) {
+		t.Fatalf("expected ErrSectionNotFound, got %v", err)
 	}
 }
 
-func TestConfigSourceType(t *testing.T) {
-	tests := []struct {
-		sourceType ConfigSourceType
-		expected   string
-	}{
-		{SourceTypeSystem, "system"},
-		{SourceTypeGlobal, "global"},
-		{SourceTypeLocal, "local"},
-		{SourceTypeWorktree, "worktree"},
+func TestConfigErrorPrefix(t *testing.T) {
+	err := &ConfigError{Op: "get", Key: "user.name", Err: ErrKeyNotFound}
+	if got := err.Error(); !strings.HasPrefix(got, "gitcfg:") {
+		t.Fatalf("unexpected error prefix: %q", got)
+	}
+}
+
+func TestLoadGlobalUsesFixtureEnvironment(t *testing.T) {
+	home := t.TempDir()
+	global := writeFile(t, home, ".gitconfig", `[user]
+	name = Fixture User
+`)
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+	t.Setenv("GIT_CONFIG_GLOBAL", global)
+
+	config, err := LoadGlobal(context.Background())
+	if err != nil {
+		t.Fatalf("LoadGlobal failed: %v", err)
+	}
+	name, err := Get[string](config, "user.name")
+	if err != nil {
+		t.Fatalf("Get user.name failed: %v", err)
+	}
+	if name != "Fixture User" {
+		t.Fatalf("unexpected user.name: %q", name)
+	}
+}
+
+func TestLoadUsesScopePrecedence(t *testing.T) {
+	dir := t.TempDir()
+	global := writeFile(t, dir, "global.gitconfig", `[core]
+	editor = vim
+`)
+	repo := dir + "/repo"
+	writeFile(t, repo, ".git/config", `[core]
+	editor = nvim
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", global)
+
+	config, err := Load(
+		context.Background(),
+		WithScopes(ScopeGlobal, ScopeLocal),
+		WithRepoPath(repo),
+	)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	assertValue(t, config, "core.editor", "nvim")
+
+	values := config.Values("core.editor")
+	if len(values) != 2 || values[0] != "vim" || values[1] != "nvim" {
+		t.Fatalf("unexpected precedence values: %#v", values)
+	}
+}
+
+func TestLoadLocalDoesNotIncludeGlobal(t *testing.T) {
+	dir := t.TempDir()
+	global := writeFile(t, dir, "global.gitconfig", `[user]
+	name = Global User
+`)
+	repo := dir + "/repo"
+	writeFile(t, repo, ".git/config", `[core]
+	editor = nvim
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", global)
+
+	config, err := LoadLocal(context.Background(), repo)
+	if err != nil {
+		t.Fatalf("LoadLocal failed: %v", err)
+	}
+	if config.Has("user.name") {
+		t.Fatal("LoadLocal should not include global config")
+	}
+	assertValue(t, config, "core.editor", "nvim")
+}
+
+func TestReloadRefreshesOriginalSources(t *testing.T) {
+	dir := t.TempDir()
+	global := writeFile(t, dir, "global.gitconfig", `[core]
+	editor = vim
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", global)
+
+	config, err := LoadGlobal(context.Background())
+	if err != nil {
+		t.Fatalf("LoadGlobal failed: %v", err)
+	}
+	assertValue(t, config, "core.editor", "vim")
+
+	if err := os.WriteFile(global, []byte("[core]\neditor = nvim\n"), 0o644); err != nil {
+		t.Fatalf("rewrite global config: %v", err)
 	}
 
-	for _, test := range tests {
-		if test.sourceType.String() != test.expected {
-			t.Errorf("Expected '%s', got '%s'", test.expected, test.sourceType.String())
+	if err := config.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload failed: %v", err)
+	}
+	assertValue(t, config, "core.editor", "nvim")
+}
+
+func TestConfigConcurrentReadReload(t *testing.T) {
+	dir := t.TempDir()
+	global := writeFile(t, dir, "global.gitconfig", `[core]
+	editor = vim
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", global)
+
+	config, err := LoadGlobal(context.Background())
+	if err != nil {
+		t.Fatalf("LoadGlobal failed: %v", err)
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					_, _ = config.Value("core.editor")
+					_ = config.Values("core.editor")
+					_ = config.Sections()
+				}
+			}
+		}()
+	}
+
+	for i := range 20 {
+		editor := "vim"
+		if i%2 == 1 {
+			editor = "nvim"
 		}
+		if err := os.WriteFile(global, []byte("[core]\neditor = "+editor+"\n"), 0o644); err != nil {
+			t.Fatalf("rewrite global config: %v", err)
+		}
+		if err := config.Reload(context.Background()); err != nil {
+			t.Fatalf("Reload failed: %v", err)
+		}
+	}
+
+	close(done)
+	wg.Wait()
+}
+
+func TestScopeString(t *testing.T) {
+	tests := map[Scope]string{
+		ScopeSystem:   "system",
+		ScopeGlobal:   "global",
+		ScopeLocal:    "local",
+		ScopeWorktree: "worktree",
+		Scope(99):     "unknown",
+	}
+
+	for scope, want := range tests {
+		if got := scope.String(); got != want {
+			t.Fatalf("Scope(%d).String() = %q, want %q", scope, got, want)
+		}
+	}
+}
+
+func mustAddEntry(t *testing.T, config *Config, key, value string, source Source) {
+	t.Helper()
+	if err := config.addEntry(key, value, source, 1); err != nil {
+		t.Fatalf("addEntry(%q) failed: %v", key, err)
 	}
 }

--- a/option.go
+++ b/option.go
@@ -1,83 +1,75 @@
 package gitcfg
 
 import (
-    "fmt"
-    "time"
-    "context"
+	"context"
+	"fmt"
+	"time"
 )
 
+// DefaultTimeout is the default timeout used by Load.
 const DefaultTimeout = 30 * time.Second
 
-type configOptions struct {
-	includeSystem   bool
-	includeGlobal   bool
-	includeLocal    bool
-	includeWorktree bool
-	repoPath        string
-	useGitCommand   bool
-	timeout         time.Duration
+type options struct {
+	scopes       []Scope
+	repoPath     string
+	includeFiles bool
+	useGit       bool
+	timeout      time.Duration
 }
 
-type ConfigOption func(*configOptions)
+// Option configures Load.
+type Option func(*options)
 
-func WithSystem() ConfigOption {
-	return func(opts *configOptions) {
-		opts.includeSystem = true
+// WithScopes selects the Git configuration scopes to load.
+func WithScopes(scopes ...Scope) Option {
+	return func(o *options) {
+		o.scopes = append(o.scopes[:0], scopes...)
 	}
 }
 
-func WithGlobal() ConfigOption {
-	return func(opts *configOptions) {
-		opts.includeGlobal = true
+// WithRepoPath sets the repository path used for local/worktree scopes and includeIf evaluation.
+func WithRepoPath(path string) Option {
+	return func(o *options) {
+		o.repoPath = path
 	}
 }
 
-func WithLocal() ConfigOption {
-	return func(opts *configOptions) {
-		opts.includeLocal = true
+// WithIncludes enables or disables include.path and includeIf handling.
+func WithIncludes(enabled bool) Option {
+	return func(o *options) {
+		o.includeFiles = enabled
 	}
 }
 
-func WithWorktree() ConfigOption {
-	return func(opts *configOptions) {
-		opts.includeWorktree = true
+// WithTimeout sets the maximum time spent loading configuration.
+func WithTimeout(timeout time.Duration) Option {
+	return func(o *options) {
+		o.timeout = timeout
 	}
 }
 
-func WithRepoPath(path string) ConfigOption {
-	return func(opts *configOptions) {
-		opts.repoPath = path
+// WithGitCommand loads configuration by invoking git config instead of the pure-Go parser.
+func WithGitCommand() Option {
+	return func(o *options) {
+		o.useGit = true
 	}
 }
 
-func WithGitCommand() ConfigOption {
-	return func(opts *configOptions) {
-		opts.useGitCommand = true
-	}
-}
-
-func WithTimeout(timeout time.Duration) ConfigOption {
-	return func(opts *configOptions) {
-		opts.timeout = timeout
-	}
-}
-
-func Load(opts ...ConfigOption) (*Config, error) {
-	return LoadWithContext(context.Background(), opts...)
-}
-
-func LoadWithContext(ctx context.Context, opts ...ConfigOption) (*Config, error) {
-	options := &configOptions{
-		includeGlobal: true, // Default to global config
-		timeout:       DefaultTimeout,
-	}
-
+// Load reads Git configuration according to opts.
+func Load(ctx context.Context, opts ...Option) (*Config, error) {
+	o := defaultOptions()
 	for _, opt := range opts {
-		opt(options)
+		opt(&o)
 	}
 
-	if (options.includeLocal || options.includeWorktree) && options.repoPath != "" {
-		if err := validateRepoPath(options.repoPath); err != nil {
+	if o.timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, o.timeout)
+		defer cancel()
+	}
+
+	if needsRepo(o.scopes) {
+		if _, err := findGitDir(o.repoPath); err != nil {
 			return nil, &ConfigError{
 				Op:  "load",
 				Err: fmt.Errorf("invalid repository path: %w", err),
@@ -85,34 +77,49 @@ func LoadWithContext(ctx context.Context, opts ...ConfigOption) (*Config, error)
 		}
 	}
 
-	parser := newParser()
-	if options.useGitCommand {
-		return parser.parseFromGitCommand(ctx, options)
+	p := newParser(parserOptions{
+		includeFiles: o.includeFiles,
+		repoPath:     o.repoPath,
+	})
+
+	if o.useGit {
+		return p.parseFromGitCommand(ctx, o)
 	}
-
-	return parser.parseFromFiles(ctx, options)
+	return p.parseFromFiles(ctx, o)
 }
 
-func LoadGlobal() (*Config, error) {
-	return Load(WithGlobal())
+// LoadGlobal loads user-level Git configuration.
+func LoadGlobal(ctx context.Context) (*Config, error) {
+	return Load(ctx, WithScopes(ScopeGlobal))
 }
 
-func LoadLocal(repoPath string) (*Config, error) {
-	return Load(WithLocal(), WithRepoPath(repoPath))
+// LoadLocal loads repository-local Git configuration.
+func LoadLocal(ctx context.Context, repoPath string) (*Config, error) {
+	return Load(ctx, WithScopes(ScopeLocal), WithRepoPath(repoPath))
 }
 
-func LoadAll(repoPath string) (*Config, error) {
-	return Load(WithSystem(), WithGlobal(), WithLocal(), WithWorktree(), WithRepoPath(repoPath))
+// LoadAll loads system, global, local, and worktree configuration in precedence order.
+func LoadAll(ctx context.Context, repoPath string) (*Config, error) {
+	return Load(
+		ctx,
+		WithScopes(ScopeSystem, ScopeGlobal, ScopeLocal, ScopeWorktree),
+		WithRepoPath(repoPath),
+	)
 }
 
-func LoadGlobalWithContext(ctx context.Context) (*Config, error) {
-	return LoadWithContext(ctx, WithGlobal())
+func defaultOptions() options {
+	return options{
+		scopes:       []Scope{ScopeGlobal},
+		includeFiles: true,
+		timeout:      DefaultTimeout,
+	}
 }
 
-func LoadLocalWithContext(ctx context.Context, repoPath string) (*Config, error) {
-	return LoadWithContext(ctx, WithLocal(), WithRepoPath(repoPath))
-}
-
-func LoadAllWithContext(ctx context.Context, repoPath string) (*Config, error) {
-	return LoadWithContext(ctx, WithSystem(), WithGlobal(), WithLocal(), WithWorktree(), WithRepoPath(repoPath))
+func needsRepo(scopes []Scope) bool {
+	for _, s := range scopes {
+		if s == ScopeLocal || s == ScopeWorktree {
+			return true
+		}
+	}
+	return false
 }

--- a/parser.go
+++ b/parser.go
@@ -6,398 +6,658 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
-	"unicode"
 )
 
+const (
+	includeSection  = "include"
+	includeIfPrefix = "includeif."
+
+	gitDirInsensitiveConditionPrefix = "gitdir/i:"
+	gitDirConditionPrefix            = "gitdir:"
+	onBranchConditionPrefix          = "onbranch:"
+)
+
+type parserOptions struct {
+	includeFiles bool
+	repoPath     string
+}
+
 type parser struct {
-	sectionRegex      *regexp.Regexp
-	keyValueRegex     *regexp.Regexp
-	commentRegex      *regexp.Regexp
-	continuationRegex *regexp.Regexp
+	opts parserOptions
 }
 
-func newParser() *parser {
-	return &parser{
-		sectionRegex:      regexp.MustCompile(`^\s*\[([^\]]+)\]\s*$`),
-		keyValueRegex:     regexp.MustCompile(`^\s*([^=\s]+)\s*=\s*(.*)$`),
-		commentRegex:      regexp.MustCompile(`^\s*[#;]`),
-		continuationRegex: regexp.MustCompile(`^\s+(.*)$`),
-	}
+type parseState struct {
+	stack map[string]bool
+	depth int
 }
 
-func (p *parser) parseFromGitCommand(ctx context.Context, opts *configOptions) (*Config, error) {
-	config := &Config{
-		sections: make(map[string]map[string]string),
-		sources:  make([]ConfigSource, 0),
+type parseFile struct {
+	cfg        *Config
+	source     Source
+	sourcePath string
+	state      *parseState
+	section    string
+}
+
+func newParser(opts parserOptions) *parser {
+	return &parser{opts: opts}
+}
+
+func newParseState() *parseState {
+	return &parseState{stack: make(map[string]bool)}
+}
+
+func (p *parser) parseFromFiles(ctx context.Context, opts options) (*Config, error) {
+	cfg := newConfig()
+	s := cfg.mutableState()
+	s.repoPath = opts.repoPath
+	s.includes = opts.includeFiles
+	s.useGit = false
+	sources := getConfigSources(opts)
+	cfg.setRoots(sources)
+
+	ps := newParseState()
+	for _, src := range sources {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if err := p.parseConfigFile(ctx, src.Path, src, cfg, ps); err != nil {
+			return nil, err
+		}
+	}
+	return cfg, nil
+}
+
+func (p *parser) parseFromGitCommand(ctx context.Context, opts options) (*Config, error) {
+	cfg := newConfig()
+	s := cfg.mutableState()
+	s.repoPath = opts.repoPath
+	s.includes = opts.includeFiles
+	s.useGit = true
+
+	sources := getConfigSources(opts)
+	cfg.setRoots(sources)
+	if len(sources) == 0 {
+		return cfg, nil
 	}
 
-	if opts.timeout > 0 {
-		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, opts.timeout)
-		defer cancel()
+	seen := make(map[Scope]bool)
+	for _, src := range sources {
+		if seen[src.Scope] {
+			continue
+		}
+		seen[src.Scope] = true
+
+		out, err := p.runGitConfig(ctx, opts, src.Scope)
+		if err != nil {
+			return nil, err
+		}
+
+		for i, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+			if line == "" {
+				continue
+			}
+
+			sourcePath, key, value := parseGitConfigOutputLine(line)
+			if key == "" {
+				continue
+			}
+
+			entrySrc := Source{Scope: src.Scope, Path: sourcePath}
+			cfg.addSource(entrySrc)
+			if err := cfg.addEntry(key, value, entrySrc, i+1); err != nil {
+				return nil, &ConfigError{Op: "parse", Key: key, Source: sourcePath, Err: err}
+			}
+		}
 	}
 
-	args := []string{"config", "--list", "--null", "--show-origin"}
+	return cfg, nil
+}
 
-	sourceFlags := p.buildSourceFlags(opts)
-	if len(sourceFlags) > 0 {
-		args = append(args, sourceFlags...)
-	}
-
+func (p *parser) runGitConfig(ctx context.Context, opts options, scope Scope) (string, error) {
+	args := []string{"config", "--list", "--show-origin", gitConfigScopeFlag(scope)}
 	cmd := exec.CommandContext(ctx, "git", args...)
 	if opts.repoPath != "" {
 		cmd.Dir = opts.repoPath
 	}
 
-	output, err := cmd.Output()
+	out, err := cmd.Output()
 	if err != nil {
-		var exitError *exec.ExitError
-		if errors.As(err, &exitError) {
-			return nil, &ConfigError{
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return "", &ConfigError{
 				Op:  "load",
-				Err: fmt.Errorf("git config failed: %s", string(exitError.Stderr)),
+				Err: fmt.Errorf("git config failed: %s", string(ee.Stderr)),
 			}
 		}
-		return nil, &ConfigError{
-			Op:  "load",
-			Err: fmt.Errorf("failed to execute git config: %w", err),
-		}
+		return "", &ConfigError{Op: "load", Err: fmt.Errorf("execute git config: %w", err)}
 	}
-
-	return p.parseGitConfigOutput(string(output), config)
+	return string(out), nil
 }
 
-func (p *parser) parseFromFiles(ctx context.Context, opts *configOptions) (*Config, error) {
-	config := &Config{
-		sections: make(map[string]map[string]string),
-		sources:  make([]ConfigSource, 0),
+func gitConfigScopeFlag(scope Scope) string {
+	switch scope {
+	case ScopeSystem:
+		return "--system"
+	case ScopeGlobal:
+		return "--global"
+	case ScopeLocal:
+		return "--local"
+	case ScopeWorktree:
+		return "--worktree"
+	default:
+		return "--global"
 	}
-
-	for _, source := range getAllConfigPaths(opts) {
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		default:
-		}
-
-		if err := p.parseConfigFile(source.Path, config); err != nil {
-			return nil, err
-		}
-		config.sources = append(config.sources, source)
-	}
-
-	return config, nil
 }
 
-func (p *parser) buildSourceFlags(opts *configOptions) []string {
-	var sourceFlags []string
-
-	if opts.includeSystem {
-		sourceFlags = append(sourceFlags, "--system")
-	}
-	if opts.includeGlobal {
-		sourceFlags = append(sourceFlags, "--global")
-	}
-	if opts.includeLocal {
-		sourceFlags = append(sourceFlags, "--local")
+func parseGitConfigOutputLine(line string) (sourcePath, key, value string) {
+	if head, rest, ok := strings.Cut(line, "\t"); ok {
+		if path, ok := strings.CutPrefix(head, "file:"); ok {
+			sourcePath = path
+		}
+		line = rest
 	}
 
-	return sourceFlags
+	key, value, ok := strings.Cut(line, "=")
+	if !ok {
+		return sourcePath, "", ""
+	}
+	return sourcePath, strings.TrimSpace(key), value
 }
 
-func (p *parser) parseGitConfigOutput(output string, config *Config) (*Config, error) {
-	lines := strings.Split(strings.TrimRight(output, "\x00"), "\x00")
-	for _, line := range lines {
-		if line == "" {
-			continue
-		}
-
-		key, value, source := p.parseGitConfigLine(line)
-		if key != "" {
-			if err := config.setRawValue(key, value); err != nil {
-				return nil, &ConfigError{
-					Op:     "parse",
-					Key:    key,
-					Source: source,
-					Err:    err,
-				}
-			}
-		}
+func (p *parser) parseConfigFile(
+	ctx context.Context,
+	path string,
+	source Source,
+	cfg *Config,
+	ps *parseState,
+) error {
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
-	return config, nil
-}
-
-func (p *parser) parseGitConfigLine(line string) (key, value, source string) {
-	// Parse show-origin format: "file:path\tkey=value"
-	if strings.HasPrefix(line, "file:") {
-		parts := strings.SplitN(line, "\t", 2)
-		if len(parts) == 2 {
-			source = strings.TrimPrefix(parts[0], "file:")
-			kvParts := strings.SplitN(parts[1], "=", 2)
-			if len(kvParts) == 2 {
-				key = strings.TrimSpace(kvParts[0])
-				value = kvParts[1]
-			}
-		}
-		return key, value, source
-	}
-
-	// Fallback for older git versions
-	parts := strings.SplitN(line, "=", 2)
-	if len(parts) == 2 {
-		key = strings.TrimSpace(parts[0])
-		value = parts[1]
-	}
-	return key, value, source
-}
-
-func (p *parser) parseConfigFile(path string, config *Config) error {
-	file, err := os.Open(path)
+	abs, err := filepath.Abs(path)
 	if err != nil {
+		return &ConfigError{Op: "parse", Source: path, Err: err}
+	}
+	source.Path = abs
+
+	if ps.stack[abs] {
+		return &ConfigError{Op: "parse", Source: abs, Err: ErrIncludeCycle}
+	}
+	if ps.depth > 100 {
 		return &ConfigError{
 			Op:     "parse",
-			Source: path,
-			Err:    fmt.Errorf("failed to open config file: %w", err),
+			Source: abs,
+			Err:    fmt.Errorf("%w: maximum include depth exceeded", ErrIncludeCycle),
 		}
 	}
-	defer file.Close()
 
-	return p.parseConfigReader(file, config, path)
+	f, err := os.Open(abs)
+	if err != nil {
+		return &ConfigError{Op: "parse", Source: abs, Err: fmt.Errorf("open config file: %w", err)}
+	}
+	defer f.Close()
+
+	cfg.addSource(source)
+	ps.stack[abs] = true
+	ps.depth++
+	defer func() {
+		ps.depth--
+		delete(ps.stack, abs)
+	}()
+
+	pf := &parseFile{
+		cfg:        cfg,
+		source:     source,
+		sourcePath: abs,
+		state:      ps,
+	}
+	return p.parseConfigReader(ctx, f, pf)
 }
 
-func (p *parser) parseConfigReader(reader io.Reader, config *Config, source string) error {
-	scanner := bufio.NewScanner(reader)
-	var currentSection string
-	lineNumber := 0
+func (p *parser) parseConfigReader(ctx context.Context, r io.Reader, pf *parseFile) error {
+	sc := bufio.NewScanner(r)
+	sc.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
-	for scanner.Scan() {
-		lineNumber++
-		line := scanner.Text()
+	var pending string
+	start := 0
+	n := 0
 
-		if line == "" || p.commentRegex.MatchString(line) {
+	flush := func(line string, n int) error {
+		return p.parseLogicalLine(ctx, pf, line, n)
+	}
+
+	for sc.Scan() {
+		n++
+		line := sc.Text()
+		if pending == "" {
+			start = n
+			pending = line
+		} else {
+			pending += strings.TrimLeft(line, " \t")
+		}
+
+		if hasContinuation(pending) {
+			pending = pending[:len(pending)-1]
 			continue
 		}
 
-		if matches := p.sectionRegex.FindStringSubmatch(line); matches != nil {
-			currentSection = strings.TrimSpace(matches[1])
-			continue
+		if err := flush(pending, start); err != nil {
+			return err
 		}
+		pending = ""
+	}
 
-		if matches := p.keyValueRegex.FindStringSubmatch(line); matches != nil {
-			key := strings.TrimSpace(matches[1])
-			value := strings.TrimSpace(matches[2])
-
-			if processedValue, err := p.processQuotedValue(value); err != nil {
-				return &ConfigError{
-					Op:     "parse",
-					Key:    key,
-					Source: fmt.Sprintf("%s:%d", source, lineNumber),
-					Err:    fmt.Errorf("invalid quoted value: %w", err),
-				}
-			} else {
-				value = processedValue
-			}
-
-			fullKey := p.buildFullKey(currentSection, key)
-			if err := config.setRawValue(fullKey, value); err != nil {
-				return &ConfigError{
-					Op:     "parse",
-					Key:    fullKey,
-					Source: fmt.Sprintf("%s:%d", source, lineNumber),
-					Err:    err,
-				}
-			}
+	if pending != "" {
+		if err := flush(pending, start); err != nil {
+			return err
 		}
 	}
 
-	if err := scanner.Err(); err != nil {
+	if err := sc.Err(); err != nil {
 		return &ConfigError{
 			Op:     "parse",
-			Source: source,
-			Err:    fmt.Errorf("scanner error: %w", err),
+			Source: pf.sourcePath,
+			Err:    fmt.Errorf("scan config file: %w", err),
+		}
+	}
+	return nil
+}
+
+func (p *parser) parseLogicalLine(ctx context.Context, pf *parseFile, line string, n int) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	s := strings.TrimSpace(line)
+	if s == "" || strings.HasPrefix(s, "#") || strings.HasPrefix(s, ";") {
+		return nil
+	}
+
+	if strings.HasPrefix(s, "[") {
+		next, err := parseSectionHeader(strings.TrimSpace(stripInlineComment(s)))
+		if err != nil {
+			return &ConfigError{
+				Op:     "parse",
+				Source: fmt.Sprintf("%s:%d", pf.sourcePath, n),
+				Err:    err,
+			}
+		}
+		pf.section = next
+		return nil
+	}
+
+	key, value, err := parseAssignment(line)
+	if err != nil {
+		return &ConfigError{Op: "parse", Source: fmt.Sprintf("%s:%d", pf.sourcePath, n), Err: err}
+	}
+
+	key = buildFullKey(pf.section, key)
+	if err := pf.cfg.addEntry(key, value, pf.source, n); err != nil {
+		return &ConfigError{
+			Op:     "parse",
+			Key:    key,
+			Source: fmt.Sprintf("%s:%d", pf.sourcePath, n),
+			Err:    err,
+		}
+	}
+
+	if p.opts.includeFiles {
+		path, ok := p.includePath(key, value, pf.sourcePath)
+		if ok {
+			src := Source{Scope: pf.source.Scope, Path: path}
+			if err := p.parseConfigFile(ctx, path, src, pf.cfg, pf.state); err != nil {
+				if errors.Is(err, fs.ErrNotExist) {
+					return nil
+				}
+				return err
+			}
 		}
 	}
 
 	return nil
 }
 
-func (p *parser) processQuotedValue(value string) (string, error) {
-	if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
-		return strconv.Unquote(value)
+func parseSectionHeader(line string) (string, error) {
+	if !strings.HasSuffix(line, "]") {
+		return "", fmt.Errorf("%w: malformed section header", ErrInvalidKeyFormat)
 	}
-	return value, nil
+	s := strings.TrimSpace(line[1 : len(line)-1])
+	if s == "" {
+		return "", fmt.Errorf("%w: empty section", ErrInvalidKeyFormat)
+	}
+
+	base, rest, ok := strings.Cut(s, " ")
+	if !ok {
+		if !isValidSection(s) {
+			return "", fmt.Errorf("%w: invalid section", ErrInvalidKeyFormat)
+		}
+		return s, nil
+	}
+
+	base = strings.TrimSpace(base)
+	rest = strings.TrimSpace(rest)
+	if base == "" || rest == "" {
+		return "", fmt.Errorf("%w: malformed subsection", ErrInvalidKeyFormat)
+	}
+	if !strings.HasPrefix(rest, `"`) || !strings.HasSuffix(rest, `"`) {
+		return "", fmt.Errorf("%w: subsection must be quoted", ErrInvalidKeyFormat)
+	}
+	sub, err := strconv.Unquote(rest)
+	if err != nil {
+		return "", fmt.Errorf("unquote subsection: %w", err)
+	}
+	return base + "." + sub, nil
 }
 
-func (p *parser) buildFullKey(section, key string) string {
-	if section == "" {
-		return key
+func parseAssignment(line string) (key, value string, err error) {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return "", "", ErrInvalidKeyFormat
 	}
 
-	// Handle subsections like remote "origin" -> remote.origin
-	if strings.Contains(section, " ") {
-		parts := strings.SplitN(section, " ", 2)
-		if len(parts) == 2 {
-			subsection := strings.TrimSpace(parts[1])
-			if len(subsection) >= 2 && subsection[0] == '"' && subsection[len(subsection)-1] == '"' {
-				return parts[0] + "." + subsection[1:len(subsection)-1] + "." + key
+	if k, v, ok := strings.Cut(line, "="); ok {
+		key = strings.TrimSpace(k)
+		value, err = parseValue(v)
+		if key == "" {
+			return "", "", ErrInvalidKeyFormat
+		}
+		return key, value, err
+	}
+
+	key = strings.TrimSpace(stripInlineComment(line))
+	if key == "" || strings.ContainsAny(key, " \t") {
+		return "", "", ErrInvalidKeyFormat
+	}
+	return key, "", nil
+}
+
+func parseValue(v string) (string, error) {
+	v = strings.TrimSpace(stripInlineComment(v))
+	if v == "" {
+		return "", nil
+	}
+	if strings.HasPrefix(v, `"`) {
+		if !strings.HasSuffix(v, `"`) {
+			return "", fmt.Errorf("%w: unterminated quoted value", ErrInvalidValue)
+		}
+		s, err := strconv.Unquote(v)
+		if err != nil {
+			return "", err
+		}
+		return s, nil
+	}
+	return v, nil
+}
+
+func stripInlineComment(s string) string {
+	quote := false
+	esc := false
+	for i, r := range s {
+		if esc {
+			esc = false
+			continue
+		}
+		switch r {
+		case '\\':
+			if quote {
+				esc = true
+			}
+		case '"':
+			quote = !quote
+		case '#', ';':
+			if !quote && (i == 0 || isSpace(s[i-1])) {
+				return s[:i]
 			}
 		}
 	}
+	return s
+}
 
+func buildFullKey(section, key string) string {
+	if section == "" {
+		return key
+	}
 	return section + "." + key
 }
 
-func isValidConfigKey(key string) bool {
-	if key == "" || !strings.Contains(key, ".") {
-		return false
+func hasContinuation(line string) bool {
+	n := 0
+	for i := len(line) - 1; i >= 0 && line[i] == '\\'; i-- {
+		n++
 	}
-	for _, r := range key {
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '.' && r != '-' && r != '_' {
-			return false
-		}
-	}
-	return true
+	return n%2 == 1
 }
 
-func isValidSectionName(name string) bool {
-	if name == "" {
-		return false
-	}
-
-	// Handle subsections like remote "origin"
-	if strings.Contains(name, " ") {
-		parts := strings.SplitN(name, " ", 2)
-		if len(parts) != 2 || !isValidKeyName(parts[0]) {
-			return false
-		}
-		subsection := strings.TrimSpace(parts[1])
-		return len(subsection) >= 2 && subsection[0] == '"' && subsection[len(subsection)-1] == '"'
-	}
-
-	return isValidKeyName(name)
+func isSpace(b byte) bool {
+	return b == ' ' || b == '\t'
 }
 
-func isValidSubsectionName(name string) bool {
-	if name == "" || !strings.Contains(name, ".") {
-		return false
+func (p *parser) includePath(key, value, sourcePath string) (string, bool) {
+	section, name, err := splitConfigKey(key)
+	if err != nil || !strings.EqualFold(name, "path") {
+		return "", false
 	}
-	for _, part := range strings.Split(name, ".") {
-		if !isValidKeyName(part) {
-			return false
+
+	switch {
+	case strings.EqualFold(section, includeSection):
+		return resolveIncludePath(value, sourcePath), true
+	case hasIncludeIfPrefix(section):
+		cond := section[len(includeIfPrefix):]
+		if p.matchIncludeCondition(cond) {
+			return resolveIncludePath(value, sourcePath), true
 		}
 	}
-	return true
+	return "", false
 }
 
-func isValidKeyName(name string) bool {
-	if name == "" {
-		return false
-	}
-
-	for _, r := range name {
-		if !unicode.IsLetter(r) && !unicode.IsDigit(r) && r != '-' && r != '_' {
-			return false
-		}
-	}
-
-	return true
+func hasIncludeIfPrefix(section string) bool {
+	return len(section) > len(includeIfPrefix) &&
+		strings.EqualFold(section[:len(includeIfPrefix)], includeIfPrefix)
 }
 
-func parseBool(value string) (bool, error) {
-	if value == "" {
-		return true, nil // Git treats empty values as true
+func resolveIncludePath(path, sourcePath string) string {
+	path = expandHome(path)
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path)
 	}
-
-	lower := strings.ToLower(strings.TrimSpace(value))
-	switch lower {
-	case "true", "yes", "on", "1":
-		return true, nil
-	case "false", "no", "off", "0":
-		return false, nil
-	default:
-		return false, fmt.Errorf("invalid boolean value: %s", value)
-	}
+	return filepath.Clean(filepath.Join(filepath.Dir(sourcePath), path))
 }
 
-func convertValue[T Constraint](value string) (T, error) {
-	var result any
-	var err error
-
-	switch any(*new(T)).(type) {
-	case string:
-		result = value
-	case int:
-		result, err = strconv.Atoi(value)
-	case int8:
-		var v int64
-		v, err = strconv.ParseInt(value, 10, 8)
-		if err == nil {
-			result = int8(v)
-		}
-	case int16:
-		var v int64
-		v, err = strconv.ParseInt(value, 10, 16)
-		if err == nil {
-			result = int16(v)
-		}
-	case int32:
-		var v int64
-		v, err = strconv.ParseInt(value, 10, 32)
-		if err == nil {
-			result = int32(v)
-		}
-	case int64:
-		result, err = strconv.ParseInt(value, 10, 64)
-	case uint:
-		var v uint64
-		v, err = strconv.ParseUint(value, 10, 0)
-		if err == nil {
-			result = uint(v)
-		}
-	case uint8:
-		var v uint64
-		v, err = strconv.ParseUint(value, 10, 8)
-		if err == nil {
-			result = uint8(v)
-		}
-	case uint16:
-		var v uint64
-		v, err = strconv.ParseUint(value, 10, 16)
-		if err == nil {
-			result = uint16(v)
-		}
-	case uint32:
-		var v uint64
-		v, err = strconv.ParseUint(value, 10, 32)
-		if err == nil {
-			result = uint32(v)
-		}
-	case uint64:
-		result, err = strconv.ParseUint(value, 10, 64)
-	case float32:
-		var v float64
-		v, err = strconv.ParseFloat(value, 32)
-		if err == nil {
-			result = float32(v)
-		}
-	case float64:
-		result, err = strconv.ParseFloat(value, 64)
-	case bool:
-		result, err = parseBool(value)
-	default:
-		err = fmt.Errorf("unsupported type")
+func expandHome(path string) string {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		return path
 	}
-
+	home, err := os.UserHomeDir()
 	if err != nil {
-		var zero T
-		return zero, fmt.Errorf("%w: %v", ErrInvalidValue, err)
+		return path
+	}
+	if path == "~" {
+		return home
+	}
+	return filepath.Join(home, path[2:])
+}
+
+func (p *parser) matchIncludeCondition(cond string) bool {
+	s := strings.ToLower(cond)
+	switch {
+	case strings.HasPrefix(s, gitDirInsensitiveConditionPrefix):
+		return p.matchGitDir(cond[len(gitDirInsensitiveConditionPrefix):], true)
+	case strings.HasPrefix(s, gitDirConditionPrefix):
+		return p.matchGitDir(cond[len(gitDirConditionPrefix):], false)
+	case strings.HasPrefix(s, onBranchConditionPrefix):
+		return p.matchBranch(cond[len(onBranchConditionPrefix):])
+	default:
+		return false
+	}
+}
+
+func (p *parser) matchGitDir(pattern string, insensitive bool) bool {
+	if p.opts.repoPath == "" {
+		return false
 	}
 
-	return result.(T), nil
+	repo, err := filepath.Abs(p.opts.repoPath)
+	if err != nil {
+		return false
+	}
+	gitDir, err := findGitDir(repo)
+	if err != nil {
+		return false
+	}
+
+	pattern = normalizeSlash(expandHome(pattern))
+	if !filepath.IsAbs(filepath.FromSlash(pattern)) && !strings.ContainsAny(pattern, "*?[") {
+		if abs, err := filepath.Abs(filepath.FromSlash(pattern)); err == nil {
+			pattern = normalizeSlash(abs)
+		}
+	}
+
+	candidates := []string{
+		ensureTrailingSlash(normalizeSlash(repo)),
+		ensureTrailingSlash(normalizeSlash(gitDir)),
+	}
+
+	if insensitive {
+		pattern = strings.ToLower(pattern)
+	}
+	for _, c := range candidates {
+		if insensitive {
+			c = strings.ToLower(c)
+		}
+		if matchPathPattern(pattern, c) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *parser) matchBranch(pattern string) bool {
+	if p.opts.repoPath == "" {
+		return false
+	}
+
+	branch, err := currentBranch(p.opts.repoPath)
+	if err != nil {
+		return false
+	}
+	return matchPathPattern(normalizeSlash(pattern), normalizeSlash(branch))
+}
+
+func currentBranch(repoPath string) (string, error) {
+	gitDir, err := findGitDir(repoPath)
+	if err != nil {
+		return "", err
+	}
+	b, err := os.ReadFile(filepath.Join(gitDir, "HEAD"))
+	if err != nil {
+		return "", err
+	}
+	s := strings.TrimSpace(string(b))
+	ref, ok := strings.CutPrefix(s, "ref: refs/heads/")
+	if !ok {
+		return "", errors.New("detached HEAD")
+	}
+	return ref, nil
+}
+
+func matchPathPattern(pattern, value string) bool {
+	pattern = normalizeSlash(pattern)
+	value = normalizeSlash(value)
+
+	if !strings.ContainsAny(pattern, "*?[") {
+		if strings.HasSuffix(pattern, "/") {
+			return strings.HasPrefix(value, pattern)
+		}
+		return strings.TrimSuffix(value, "/") == strings.TrimSuffix(pattern, "/")
+	}
+
+	re, err := regexp.Compile(globToRegexp(pattern))
+	if err != nil {
+		return false
+	}
+	return re.MatchString(value)
+}
+
+func globToRegexp(pattern string) string {
+	var b strings.Builder
+	b.WriteString("^")
+	for i := 0; i < len(pattern); i++ {
+		switch pattern[i] {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				b.WriteString(".*")
+				i++
+			} else {
+				b.WriteString("[^/]*")
+			}
+		case '?':
+			b.WriteString("[^/]")
+		case '[':
+			end := globClassEnd(pattern, i+1)
+			if end == -1 {
+				b.WriteString(`\[`)
+				continue
+			}
+			b.WriteString(globClassToRegexp(pattern[i+1 : end]))
+			i = end
+		default:
+			b.WriteString(regexp.QuoteMeta(pattern[i : i+1]))
+		}
+	}
+	b.WriteString("$")
+	return b.String()
+}
+
+func globClassEnd(pattern string, start int) int {
+	for i := start; i < len(pattern); i++ {
+		if pattern[i] == ']' && i > start {
+			return i
+		}
+	}
+	return -1
+}
+
+func globClassToRegexp(class string) string {
+	var b strings.Builder
+	b.WriteByte('[')
+	if strings.HasPrefix(class, "!") {
+		b.WriteByte('^')
+		class = class[1:]
+	} else if strings.HasPrefix(class, "^") {
+		b.WriteString(`\^`)
+		class = class[1:]
+	}
+
+	for i := 0; i < len(class); i++ {
+		switch class[i] {
+		case '\\':
+			b.WriteString(`\\`)
+		case '[':
+			b.WriteString(`\[`)
+		default:
+			b.WriteByte(class[i])
+		}
+	}
+	b.WriteByte(']')
+	return b.String()
+}
+
+func normalizeSlash(path string) string {
+	return filepath.ToSlash(filepath.Clean(path))
+}
+
+func ensureTrailingSlash(path string) string {
+	if strings.HasSuffix(path, "/") {
+		return path
+	}
+	return path + "/"
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -2,347 +2,283 @@ package gitcfg
 
 import (
 	"context"
+	"errors"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
 
-func TestNewParser(t *testing.T) {
-	parser := newParser()
-	if parser == nil {
-		t.Fatal("Parser is nil")
-	}
-	if parser.sectionRegex == nil {
-		t.Error("Section regex is nil")
-	}
-	if parser.keyValueRegex == nil {
-		t.Error("Key-value regex is nil")
-	}
-}
-
-func TestParseConfigReader(t *testing.T) {
-	parser := newParser()
-	config := &Config{
-		sections: make(map[string]map[string]string),
-	}
-
-	configData := `[user]
-    name = Test User
-    email = test@example.com
+func TestParseConfigReaderSupportsGitSyntax(t *testing.T) {
+	data := `[user]
+	name = Test User
+	email = "test@example.com" # inline comment
 
 [core]
-    editor = vim
-    autocrlf = true
+	editor = vim
+	filemode
+	long = first\
+second
+
+[remote "origin"] ; section comment
+	url = git@example.com:repo.git
+	fetch = +refs/heads/*:refs/remotes/origin/*
+
+[includeIf "gitdir:~/Git/abilia/"]
+	path = ~/.gitconfig-abilia
+
+[url "git@gitlab.com:"]
+	insteadOf = https://gitlab.com/
 `
 
-	reader := strings.NewReader(configData)
-	err := parser.parseConfigReader(reader, config, "test")
+	config := newConfig()
+	parser := newParser(parserOptions{})
+	err := parser.parseConfigReader(
+		context.Background(),
+		strings.NewReader(data),
+		&parseFile{
+			cfg:        config,
+			source:     Source{Scope: ScopeGlobal, Path: "/tmp/gitconfig"},
+			sourcePath: "/tmp/gitconfig",
+			state:      newParseState(),
+		},
+	)
 	if err != nil {
 		t.Fatalf("parseConfigReader failed: %v", err)
 	}
 
-	if config.sections["user"]["name"] != "Test User" {
-		t.Errorf("Expected 'Test User', got '%s'", config.sections["user"]["name"])
-	}
-	if config.sections["user"]["email"] != "test@example.com" {
-		t.Errorf("Expected 'test@example.com', got '%s'", config.sections["user"]["email"])
-	}
-	if config.sections["core"]["editor"] != "vim" {
-		t.Errorf("Expected 'vim', got '%s'", config.sections["core"]["editor"])
-	}
-}
+	assertValue(t, config, "user.email", "test@example.com")
+	assertValue(t, config, "core.long", "firstsecond")
+	assertValue(t, config, "remote.origin.url", "git@example.com:repo.git")
+	assertValue(t, config, "includeIf.gitdir:~/Git/abilia/.path", "~/.gitconfig-abilia")
+	assertValue(t, config, "url.git@gitlab.com:.insteadOf", "https://gitlab.com/")
 
-func TestParseGitConfigLine(t *testing.T) {
-	parser := newParser()
-
-	tests := []struct {
-		line           string
-		expectedKey    string
-		expectedValue  string
-		expectedSource string
-	}{
-		{"file:/home/user/.gitconfig\tuser.name=Test User", "user.name", "Test User", "/home/user/.gitconfig"},
-		{"file:/etc/gitconfig\tcore.editor=vim", "core.editor", "vim", "/etc/gitconfig"},
-		{"user.email=test@example.com", "user.email", "test@example.com", ""},
-	}
-
-	for _, test := range tests {
-		key, value, source := parser.parseGitConfigLine(test.line)
-		if key != test.expectedKey {
-			t.Errorf("Expected key '%s', got '%s'", test.expectedKey, key)
-		}
-		if value != test.expectedValue {
-			t.Errorf("Expected value '%s', got '%s'", test.expectedValue, value)
-		}
-		if source != test.expectedSource {
-			t.Errorf("Expected source '%s', got '%s'", test.expectedSource, source)
-		}
-	}
-}
-
-func TestProcessQuotedValue(t *testing.T) {
-	parser := newParser()
-
-	tests := []struct {
-		input    string
-		expected string
-	}{
-		{`"quoted value"`, "quoted value"},
-		{`unquoted value`, "unquoted value"},
-		{`"value with spaces"`, "value with spaces"},
-		{`"value with \"quotes\""`, `value with "quotes"`},
-	}
-
-	for _, test := range tests {
-		result, err := parser.processQuotedValue(test.input)
-		if err != nil {
-			t.Errorf("processQuotedValue failed for '%s': %v", test.input, err)
-		}
-		if result != test.expected {
-			t.Errorf("Expected '%s', got '%s'", test.expected, result)
-		}
-	}
-}
-
-func TestBuildFullKey(t *testing.T) {
-	parser := newParser()
-
-	tests := []struct {
-		section  string
-		key      string
-		expected string
-	}{
-		{"user", "name", "user.name"},
-		{"core", "editor", "core.editor"},
-		{"", "key", "key"},
-		{"remote \"origin\"", "url", "remote.origin.url"},
-		{"branch \"main\"", "remote", "branch.main.remote"},
-		{"submodule \"path/to/sub\"", "url", "submodule.path/to/sub.url"},
-	}
-
-	for _, test := range tests {
-		result := parser.buildFullKey(test.section, test.key)
-		if result != test.expected {
-			t.Errorf("Expected '%s', got '%s'", test.expected, result)
-		}
-	}
-}
-
-func TestIsValidConfigKey(t *testing.T) {
-	tests := []struct {
-		key      string
-		expected bool
-	}{
-		{"user.name", true},
-		{"core.editor", true},
-		{"remote.origin.url", true},
-		{"invalid", false},
-		{"", false},
-		{"user.name.extra", true},
-	}
-
-	for _, test := range tests {
-		result := isValidConfigKey(test.key)
-		if result != test.expected {
-			t.Errorf("Expected %v for key '%s', got %v", test.expected, test.key, result)
-		}
-	}
-}
-
-func TestIsValidSectionName(t *testing.T) {
-	tests := []struct {
-		name     string
-		expected bool
-	}{
-		{"user", true},
-		{"core", true},
-		{"remote", true},
-		{"", false},
-		{"user-section", true},
-		{"user_section", true},
-		{"123invalid", true},
-		{"remote \"origin\"", true},
-	}
-
-	for _, test := range tests {
-		result := isValidSectionName(test.name)
-		if result != test.expected {
-			t.Errorf("Expected %v for section '%s', got %v", test.expected, test.name, result)
-		}
-	}
-}
-
-func TestIsValidKeyName(t *testing.T) {
-	tests := []struct {
-		name     string
-		expected bool
-	}{
-		{"name", true},
-		{"editor", true},
-		{"url", true},
-		{"", false},
-		{"key-name", true},
-		{"key_name", true},
-		{"123key", true},
-	}
-
-	for _, test := range tests {
-		result := isValidKeyName(test.name)
-		if result != test.expected {
-			t.Errorf("Expected %v for key '%s', got %v", test.expected, test.name, result)
-		}
-	}
-}
-
-func TestParseBool(t *testing.T) {
-	tests := []struct {
-		value    string
-		expected bool
-		hasError bool
-	}{
-		{"true", true, false},
-		{"false", false, false},
-		{"yes", true, false},
-		{"no", false, false},
-		{"on", true, false},
-		{"off", false, false},
-		{"1", true, false},
-		{"0", false, false},
-		{"", true, false}, // Git treats empty as true
-		{"invalid", false, true},
-	}
-
-	for _, test := range tests {
-		result, err := parseBool(test.value)
-		if test.hasError {
-			if err == nil {
-				t.Errorf("Expected error for value '%s'", test.value)
-			}
-		} else {
-			if err != nil {
-				t.Errorf("Unexpected error for value '%s': %v", test.value, err)
-			}
-			if result != test.expected {
-				t.Errorf("Expected %v for value '%s', got %v", test.expected, test.value, result)
-			}
-		}
-	}
-}
-
-func TestConvertValue(t *testing.T) {
-	t.Run("string", func(t *testing.T) {
-		result, err := convertValue[string]("test")
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		if result != "test" {
-			t.Errorf("Expected 'test', got '%s'", result)
-		}
-	})
-
-	t.Run("int", func(t *testing.T) {
-		result, err := convertValue[int]("42")
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		if result != 42 {
-			t.Errorf("Expected 42, got %d", result)
-		}
-	})
-
-	t.Run("bool", func(t *testing.T) {
-		result, err := convertValue[bool]("true")
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		if result != true {
-			t.Errorf("Expected true, got %v", result)
-		}
-	})
-
-	t.Run("float64", func(t *testing.T) {
-		result, err := convertValue[float64]("3.14")
-		if err != nil {
-			t.Errorf("Unexpected error: %v", err)
-		}
-		if result != 3.14 {
-			t.Errorf("Expected 3.14, got %f", result)
-		}
-	})
-}
-
-func TestParseFromGitCommand(t *testing.T) {
-	parser := newParser()
-	opts := &configOptions{
-		includeGlobal: true,
-		timeout:       DefaultTimeout,
-	}
-
-	ctx := context.Background()
-	config, err := parser.parseFromGitCommand(ctx, opts)
-
-	// This test may fail if git is not available or configured
+	filemode, err := Get[bool](config, "core.filemode")
 	if err != nil {
-		t.Logf("parseFromGitCommand failed (expected if git not available): %v", err)
-		return
+		t.Fatalf("Get core.filemode failed: %v", err)
 	}
-
-	if config == nil {
-		t.Error("Config is nil")
+	if !filemode {
+		t.Fatal("expected bare bool key to parse as true")
 	}
 }
 
-func TestSubsectionParsing(t *testing.T) {
-	parser := newParser()
-	config := &Config{
-		sections: make(map[string]map[string]string),
-	}
+func TestLoadFollowsIncludes(t *testing.T) {
+	dir := t.TempDir()
+	included := writeFile(t, dir, "included.gitconfig", `[user]
+	name = Included User
+`)
+	main := writeFile(t, dir, "main.gitconfig", `[include]
+	path = included.gitconfig
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", main)
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", "")
 
-	// Test config with subsections
-	configData := `[user]
-    name = Test User
-    email = test@example.com
-
-[core]
-    editor = vim
-    autocrlf = true
-
-[remote "origin"]
-    url = https://github.com/example/repo.git
-    fetch = +refs/heads/*:refs/remotes/origin/*
-
-[remote "upstream"]
-    url = https://github.com/upstream/repo.git
-    fetch = +refs/heads/*:refs/remotes/upstream/*
-
-[branch "main"]
-    remote = origin
-    merge = refs/heads/main
-`
-
-	reader := strings.NewReader(configData)
-	err := parser.parseConfigReader(reader, config, "test")
+	config, err := Load(context.Background(), WithScopes(ScopeGlobal))
 	if err != nil {
-		t.Fatalf("parseConfigReader failed: %v", err)
+		t.Fatalf("Load failed: %v", err)
+	}
+	assertValue(t, config, "user.name", "Included User")
+
+	sources := config.Sources()
+	if len(sources) != 2 || sources[0].Path != main || sources[1].Path != included {
+		t.Fatalf("unexpected sources: %#v", sources)
+	}
+}
+
+func TestLoadIgnoresMissingInclude(t *testing.T) {
+	dir := t.TempDir()
+	main := writeFile(t, dir, "main.gitconfig", `[include]
+	path = missing.gitconfig
+
+[user]
+	name = Present User
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", main)
+
+	config, err := Load(context.Background(), WithScopes(ScopeGlobal))
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	assertValue(t, config, "user.name", "Present User")
+}
+
+func TestLoadCanDisableIncludes(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "included.gitconfig", `[user]
+	name = Included User
+`)
+	main := writeFile(t, dir, "main.gitconfig", `[include]
+	path = included.gitconfig
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", main)
+
+	config, err := Load(context.Background(), WithScopes(ScopeGlobal), WithIncludes(false))
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if config.Has("user.name") {
+		t.Fatal("did not expect include to be followed")
+	}
+	assertValue(t, config, "include.path", "included.gitconfig")
+}
+
+func TestLoadFollowsGitdirConditionalInclude(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	writeFile(t, repo, ".git/HEAD", "ref: refs/heads/main\n")
+
+	writeFile(t, dir, "conditional.gitconfig", `[user]
+email = repo@example.com
+`)
+	main := writeFile(t, dir, "main.gitconfig", `[includeIf "gitdir:`+filepath.ToSlash(repo)+`/"]
+	path = conditional.gitconfig
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", main)
+
+	config, err := Load(context.Background(), WithScopes(ScopeGlobal), WithRepoPath(repo))
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	assertValue(t, config, "user.email", "repo@example.com")
+}
+
+func TestGitdirConditionalIncludeSupportsBracketGlob(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "Work")
+	writeFile(t, repo, ".git/HEAD", "ref: refs/heads/main\n")
+
+	writeFile(t, dir, "conditional.gitconfig", `[user]
+email = work@example.com
+`)
+	main := writeFile(
+		t,
+		dir,
+		"main.gitconfig",
+		`[includeIf "gitdir:`+filepath.ToSlash(filepath.Join(dir, "[wW]ork"))+`/"]
+	path = conditional.gitconfig
+`,
+	)
+	t.Setenv("GIT_CONFIG_GLOBAL", main)
+
+	config, err := Load(context.Background(), WithScopes(ScopeGlobal), WithRepoPath(repo))
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	assertValue(t, config, "user.email", "work@example.com")
+}
+
+func TestLoadFollowsOnBranchConditionalInclude(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	writeFile(t, repo, ".git/HEAD", "ref: refs/heads/main\n")
+
+	conditional := writeFile(t, dir, "branch.gitconfig", `[core]
+	editor = nvim
+`)
+	main := writeFile(t, dir, "main.gitconfig", `[includeIf "onbranch:main"]
+	path = `+conditional+`
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", main)
+
+	config, err := Load(context.Background(), WithScopes(ScopeGlobal), WithRepoPath(repo))
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	assertValue(t, config, "core.editor", "nvim")
+}
+
+func TestLoadWithGitCommand(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git command not available")
 	}
 
-	// Test that subsections are parsed correctly
-	expectedSections := []string{"user", "core", "remote.origin", "remote.upstream", "branch.main"}
-	for _, expectedSection := range expectedSections {
-		if _, exists := config.sections[expectedSection]; !exists {
-			t.Errorf("Expected section '%s' not found", expectedSection)
-		}
+	dir := t.TempDir()
+	global := writeFile(t, dir, "global.gitconfig", `[user]
+	name = Git Command User
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", global)
+	t.Setenv("HOME", dir)
+
+	config, err := Load(context.Background(), WithScopes(ScopeGlobal), WithGitCommand())
+	if err != nil {
+		t.Fatalf("Load with git command failed: %v", err)
+	}
+	assertValue(t, config, "user.name", "Git Command User")
+}
+
+func TestReloadPreservesGitCommandLoader(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git command not available")
 	}
 
-	// Test accessing subsection values
-	if config.sections["remote.origin"]["url"] != "https://github.com/example/repo.git" {
-		t.Errorf("Expected origin URL, got '%s'", config.sections["remote.origin"]["url"])
+	dir := t.TempDir()
+	writeFile(t, dir, "global.gitconfig", `[user]
+	name = Before Reload
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", filepath.Join(dir, "global.gitconfig"))
+	t.Setenv("HOME", dir)
+
+	config, err := Load(context.Background(), WithScopes(ScopeGlobal), WithGitCommand())
+	if err != nil {
+		t.Fatalf("Load with git command failed: %v", err)
+	}
+	if !config.snapshot().useGit {
+		t.Fatal("expected config to preserve git-command loader mode")
 	}
 
-	if config.sections["remote.upstream"]["url"] != "https://github.com/upstream/repo.git" {
-		t.Errorf("Expected upstream URL, got '%s'", config.sections["remote.upstream"]["url"])
+	writeFile(t, dir, "global.gitconfig", `[user]
+	name = After Reload
+`)
+	if err := config.Reload(context.Background()); err != nil {
+		t.Fatalf("Reload failed: %v", err)
 	}
+	if !config.snapshot().useGit {
+		t.Fatal("Reload should preserve git-command loader mode")
+	}
+	assertValue(t, config, "user.name", "After Reload")
+}
 
-	if config.sections["branch.main"]["remote"] != "origin" {
-		t.Errorf("Expected branch main remote 'origin', got '%s'", config.sections["branch.main"]["remote"])
+func TestIncludeCycleReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	a := writeFile(t, dir, "a.gitconfig", `[include]
+	path = b.gitconfig
+`)
+	writeFile(t, dir, "b.gitconfig", `[include]
+	path = a.gitconfig
+`)
+	t.Setenv("GIT_CONFIG_GLOBAL", a)
+
+	_, err := Load(context.Background(), WithScopes(ScopeGlobal))
+	if !errors.Is(err, ErrIncludeCycle) {
+		t.Fatalf("expected ErrIncludeCycle, got %v", err)
+	}
+}
+
+func TestParseMalformedConfig(t *testing.T) {
+	parser := newParser(parserOptions{})
+	err := parser.parseConfigReader(
+		context.Background(),
+		strings.NewReader("[core\neditor = vim\n"),
+		&parseFile{
+			cfg:        newConfig(),
+			source:     Source{Scope: ScopeGlobal, Path: "/tmp/gitconfig"},
+			sourcePath: "/tmp/gitconfig",
+			state:      newParseState(),
+		},
+	)
+	if !errors.Is(err, ErrInvalidKeyFormat) {
+		t.Fatalf("expected ErrInvalidKeyFormat, got %v", err)
+	}
+}
+
+func assertValue(t *testing.T, config *Config, key, want string) {
+	t.Helper()
+	got, err := config.Value(key)
+	if err != nil {
+		t.Fatalf("Value(%q) failed: %v", key, err)
+	}
+	if got != want {
+		t.Fatalf("Value(%q) = %q, want %q", key, got, want)
 	}
 }

--- a/paths.go
+++ b/paths.go
@@ -4,116 +4,103 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 )
 
 const (
-	SystemConfigFile = "/etc/gitconfig"         // default system configuration file path.
-	GlobalConfigFile = ".gitconfig"             // default global configuration file name.
-	LocalConfigFile = ".git/config"             // default local configuration file path.
-	WorktreeConfigFile = ".git/config.worktree" // default worktree configuration file path.
-	XDGConfigDir = ".config/git/config"         // XDG configuration directory.
+	// SystemConfigFile is the default system configuration path.
+	SystemConfigFile = "/etc/gitconfig"
+	// GlobalConfigFile is the default home relative global configuration file.
+	GlobalConfigFile = ".gitconfig"
+	// LocalConfigFile is the repository gitdir configuration file.
+	LocalConfigFile = "config"
+	// WorktreeConfigFile is the repository gitdir worktree configuration file.
+	WorktreeConfigFile = "config.worktree"
+	// XDGConfigFile is the home-relative XDG global configuration file.
+	XDGConfigFile = ".config/git/config"
 )
 
-func validateRepoPath(path string) error {
-	if path == "" {
-		return errors.New("empty path")
-	}
-
-	info, err := os.Stat(path)
-	if err != nil {
-		return fmt.Errorf("path does not exist: %w", err)
-	}
-
-	if !info.IsDir() {
-		return errors.New("path is not a directory")
-	}
-
-	gitDir := filepath.Join(path, ".git")
-	if _, err := os.Stat(gitDir); err != nil {
-		return errors.New("not a Git repository")
-	}
-
-	return nil
-}
-
-func getSystemConfigPath() string {
-	// Try to get from git config --system --list first
-	if path := getSystemConfigPathFromGit(); path != "" {
-		return path
-	}
-
-	return getSystemConfigPathFallback()
-}
-
-func getSystemConfigPathFromGit() string {
-    cmd := exec.Command("git", "config", "--system", "--show-origin", "--list")
-	output, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-
-	return parseSystemConfigPath(string(output))
-}
-
-func parseSystemConfigPath(output string) string {
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if strings.HasPrefix(line, "file:") {
-			parts := strings.SplitN(line, "\t", 2)
-			if len(parts) > 0 {
-				return strings.TrimPrefix(parts[0], "file:")
+func getConfigSources(opts options) []Source {
+	var srcs []Source
+	for _, s := range opts.scopes {
+		switch s {
+		case ScopeSystem:
+			for _, p := range getSystemConfigPaths() {
+				srcs = append(srcs, Source{Scope: ScopeSystem, Path: p})
+			}
+		case ScopeGlobal:
+			for _, p := range getGlobalConfigPaths() {
+				srcs = append(srcs, Source{Scope: ScopeGlobal, Path: p})
+			}
+		case ScopeLocal:
+			if p := getLocalConfigPath(opts.repoPath); p != "" {
+				srcs = append(srcs, Source{Scope: ScopeLocal, Path: p})
+			}
+		case ScopeWorktree:
+			if p := getWorktreeConfigPath(opts.repoPath); p != "" {
+				srcs = append(srcs, Source{Scope: ScopeWorktree, Path: p})
 			}
 		}
 	}
-	return ""
+	return srcs
 }
 
-func getSystemConfigPathFallback() string {
-	paths := []string{
-		SystemConfigFile,
-		"/usr/local/etc/gitconfig",
+func getSystemConfigPaths() []string {
+	if os.Getenv("GIT_CONFIG_NOSYSTEM") != "" {
+		return nil
+	}
+	if p := os.Getenv("GIT_CONFIG_SYSTEM"); p != "" {
+		if fileExists(p) {
+			return []string{p}
+		}
+		return nil
 	}
 
-	for _, path := range paths {
-		if _, err := os.Stat(path); err == nil {
-			return path
+	var ps []string
+	for _, p := range []string{SystemConfigFile, "/usr/local/etc/gitconfig"} {
+		if fileExists(p) {
+			ps = append(ps, p)
 		}
 	}
-
-	return ""
+	return ps
 }
 
-func getGlobalConfigPath() string {
-	if path := getXDGConfigPath(); path != "" {
-		return path
+func getGlobalConfigPaths() []string {
+	if p := os.Getenv("GIT_CONFIG_GLOBAL"); p != "" {
+		if fileExists(p) {
+			return []string{p}
+		}
+		return nil
 	}
 
-	if path := getHomeConfigPath(); path != "" {
-		return path
+	var ps []string
+	if p := getXDGConfigPath(); p != "" {
+		ps = append(ps, p)
 	}
-
-	return ""
+	if p := getHomeConfigPath(); p != "" {
+		ps = append(ps, p)
+	}
+	return ps
 }
 
 func getXDGConfigPath() string {
-	xdgConfig := os.Getenv("XDG_CONFIG_HOME")
-	if xdgConfig != "" {
-		xdgPath := filepath.Join(xdgConfig, "git", "config")
-		if _, err := os.Stat(xdgPath); err == nil {
-			return xdgPath
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		p := filepath.Join(dir, "git", "config")
+		if fileExists(p) {
+			return p
 		}
+		return ""
 	}
 
-	if home, err := os.UserHomeDir(); err == nil {
-		xdgPath := filepath.Join(home, XDGConfigDir)
-		if _, err := os.Stat(xdgPath); err == nil {
-			return xdgPath
-		}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
 	}
-
+	p := filepath.Join(home, XDGConfigFile)
+	if fileExists(p) {
+		return p
+	}
 	return ""
 }
 
@@ -122,79 +109,92 @@ func getHomeConfigPath() string {
 	if err != nil {
 		return ""
 	}
-
-	globalPath := filepath.Join(home, GlobalConfigFile)
-	if _, err := os.Stat(globalPath); err == nil {
-		return globalPath
+	p := filepath.Join(home, GlobalConfigFile)
+	if fileExists(p) {
+		return p
 	}
-
 	return ""
 }
 
 func getLocalConfigPath(repoPath string) string {
-	if repoPath == "" {
+	dir, err := findGitDir(repoPath)
+	if err != nil {
 		return ""
 	}
-
-	localPath := filepath.Join(repoPath, LocalConfigFile)
-	if _, err := os.Stat(localPath); err == nil {
-		return localPath
+	p := filepath.Join(dir, LocalConfigFile)
+	if fileExists(p) {
+		return p
 	}
-
 	return ""
 }
 
 func getWorktreeConfigPath(repoPath string) string {
-	if repoPath == "" {
+	dir, err := findGitDir(repoPath)
+	if err != nil {
 		return ""
 	}
-
-	worktreePath := filepath.Join(repoPath, WorktreeConfigFile)
-	if _, err := os.Stat(worktreePath); err == nil {
-		return worktreePath
+	p := filepath.Join(dir, WorktreeConfigFile)
+	if fileExists(p) {
+		return p
 	}
-
 	return ""
 }
 
-func getAllConfigPaths(opts *configOptions) []ConfigSource {
-	var sources []ConfigSource
-
-	if opts.includeSystem {
-		if path := getSystemConfigPath(); path != "" {
-			sources = append(sources, ConfigSource{
-				Type: SourceTypeSystem,
-				Path: path,
-			})
-		}
+func findGitDir(repoPath string) (string, error) {
+	if strings.TrimSpace(repoPath) == "" {
+		return "", errors.New("empty path")
 	}
 
-	if opts.includeGlobal {
-		if path := getGlobalConfigPath(); path != "" {
-			sources = append(sources, ConfigSource{
-				Type: SourceTypeGlobal,
-				Path: path,
-			})
-		}
+	repoPath, err := filepath.Abs(repoPath)
+	if err != nil {
+		return "", err
 	}
 
-	if opts.includeLocal && opts.repoPath != "" {
-		if path := getLocalConfigPath(opts.repoPath); path != "" {
-			sources = append(sources, ConfigSource{
-				Type: SourceTypeLocal,
-				Path: path,
-			})
-		}
+	fi, err := os.Stat(repoPath)
+	if err != nil {
+		return "", fmt.Errorf("path does not exist: %w", err)
+	}
+	if !fi.IsDir() {
+		return "", errors.New("path is not a directory")
 	}
 
-	if opts.includeWorktree && opts.repoPath != "" {
-		if path := getWorktreeConfigPath(opts.repoPath); path != "" {
-			sources = append(sources, ConfigSource{
-				Type: SourceTypeWorktree,
-				Path: path,
-			})
-		}
+	gitPath := filepath.Join(repoPath, ".git")
+	fi, err = os.Stat(gitPath)
+	if err != nil {
+		return "", errors.New("not a Git repository")
+	}
+	if fi.IsDir() {
+		return gitPath, nil
 	}
 
-	return sources
+	b, err := os.ReadFile(gitPath)
+	if err != nil {
+		return "", fmt.Errorf("read .git file: %w", err)
+	}
+
+	s := strings.TrimSpace(string(b))
+	dir, ok := strings.CutPrefix(s, "gitdir:")
+	if !ok {
+		return "", errors.New("invalid .git file")
+	}
+
+	dir = strings.TrimSpace(dir)
+	if !filepath.IsAbs(dir) {
+		dir = filepath.Join(repoPath, dir)
+	}
+
+	dir = filepath.Clean(dir)
+	fi, err = os.Stat(dir)
+	if err != nil {
+		return "", fmt.Errorf("gitdir does not exist: %w", err)
+	}
+	if !fi.IsDir() {
+		return "", errors.New("gitdir is not a directory")
+	}
+	return dir, nil
+}
+
+func fileExists(path string) bool {
+	fi, err := os.Stat(path)
+	return err == nil && !fi.IsDir()
 }

--- a/paths_test.go
+++ b/paths_test.go
@@ -7,193 +7,115 @@ import (
 )
 
 func TestValidateRepoPath(t *testing.T) {
-	err := validateRepoPath("")
-	if err == nil {
-		t.Error("Expected error for empty path")
+	if _, err := findGitDir(""); err == nil {
+		t.Fatal("expected empty path to fail")
+	}
+	if _, err := findGitDir(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("expected missing path to fail")
 	}
 
-	err = validateRepoPath("/nonexistent/path")
-	if err == nil {
-		t.Error("Expected error for non-existent path")
+	dir := t.TempDir()
+	if _, err := findGitDir(dir); err == nil {
+		t.Fatal("expected non-repository to fail")
 	}
 
-	tempDir, err := os.MkdirTemp("", "test-repo")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	err = validateRepoPath(tempDir)
-	if err == nil {
-		t.Error("Expected error for non-git directory")
-	}
-
-	gitDir := filepath.Join(tempDir, ".git")
-	err = os.Mkdir(gitDir, 0755)
-	if err != nil {
-		t.Fatalf("Failed to create .git dir: %v", err)
-	}
-
-	err = validateRepoPath(tempDir)
-	if err != nil {
-		t.Errorf("Unexpected error for valid git repo: %v", err)
+	writeFile(t, dir, ".git/HEAD", "ref: refs/heads/main\n")
+	if _, err := findGitDir(dir); err != nil {
+		t.Fatalf("expected .git directory repository to pass: %v", err)
 	}
 }
 
-func TestGetSystemConfigPath(t *testing.T) {
-	path := getSystemConfigPath()
-	t.Logf("System config path: %s", path)
-}
-
-func TestGetGlobalConfigPath(t *testing.T) {
-	path := getGlobalConfigPath()
-	t.Logf("Global config path: %s", path)
-}
-
-func TestGetLocalConfigPath(t *testing.T) {
-	path := getLocalConfigPath("")
-	if path != "" {
-		t.Errorf("Expected empty path, got '%s'", path)
+func TestValidateRepoPathSupportsGitFile(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "repo")
+	gitDir := filepath.Join(dir, "actual.git")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
 	}
-
-	path = getLocalConfigPath("/nonexistent/path")
-	if path != "" {
-		t.Errorf("Expected empty path, got '%s'", path)
+	if err := os.MkdirAll(gitDir, 0o755); err != nil {
+		t.Fatalf("mkdir git dir: %v", err)
 	}
+	writeFile(t, repo, ".git", "gitdir: ../actual.git\n")
 
-	tempDir, err := os.MkdirTemp("", "test-repo")
+	got, err := findGitDir(repo)
 	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
+		t.Fatalf("findGitDir failed: %v", err)
 	}
-	defer os.RemoveAll(tempDir)
-
-	gitDir := filepath.Join(tempDir, ".git")
-	err = os.Mkdir(gitDir, 0755)
-	if err != nil {
-		t.Fatalf("Failed to create .git dir: %v", err)
-	}
-
-	configPath := filepath.Join(gitDir, "config")
-	err = os.WriteFile(configPath, []byte("[test]\n"), 0644)
-	if err != nil {
-		t.Fatalf("Failed to create config file: %v", err)
-	}
-
-	path = getLocalConfigPath(tempDir)
-	if path != configPath {
-		t.Errorf("Expected '%s', got '%s'", configPath, path)
+	if got != gitDir {
+		t.Fatalf("findGitDir = %q, want %q", got, gitDir)
 	}
 }
 
-func TestGetWorktreeConfigPath(t *testing.T) {
-	path := getWorktreeConfigPath("")
-	if path != "" {
-		t.Errorf("Expected empty path, got '%s'", path)
-	}
+func TestGlobalConfigPathsIncludeXDGAndHome(t *testing.T) {
+	home := t.TempDir()
+	xdg := filepath.Join(home, "xdg")
+	xdgPath := writeFile(t, xdg, "git/config", "[core]\n")
+	homePath := writeFile(t, home, ".gitconfig", "[user]\n")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("GIT_CONFIG_GLOBAL", "")
 
-	path = getWorktreeConfigPath("/nonexistent/path")
-	if path != "" {
-		t.Errorf("Expected empty path, got '%s'", path)
-	}
-
-	tempDir, err := os.MkdirTemp("", "test-repo")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(tempDir)
-
-	gitDir := filepath.Join(tempDir, ".git")
-	err = os.Mkdir(gitDir, 0755)
-	if err != nil {
-		t.Fatalf("Failed to create .git dir: %v", err)
-	}
-
-	configPath := filepath.Join(gitDir, "config.worktree")
-	err = os.WriteFile(configPath, []byte("[test]\n"), 0644)
-	if err != nil {
-		t.Fatalf("Failed to create config file: %v", err)
-	}
-
-	path = getWorktreeConfigPath(tempDir)
-	if path != configPath {
-		t.Errorf("Expected '%s', got '%s'", configPath, path)
+	paths := getGlobalConfigPaths()
+	if len(paths) != 2 || paths[0] != xdgPath || paths[1] != homePath {
+		t.Fatalf("unexpected global paths: %#v", paths)
 	}
 }
 
-func TestGetAllConfigPaths(t *testing.T) {
-	opts := &configOptions{
-		includeGlobal: true,
-	}
+func TestGlobalConfigEnvOverride(t *testing.T) {
+	dir := t.TempDir()
+	override := writeFile(t, dir, "override.gitconfig", "[user]\n")
+	t.Setenv("GIT_CONFIG_GLOBAL", override)
 
-	sources := getAllConfigPaths(opts)
-	t.Logf("Found %d config sources", len(sources))
-
-	for _, source := range sources {
-		t.Logf("Source: %s - %s", source.Type, source.Path)
+	paths := getGlobalConfigPaths()
+	if len(paths) != 1 || paths[0] != override {
+		t.Fatalf("unexpected override paths: %#v", paths)
 	}
 }
 
-func TestGetXDGConfigPath(t *testing.T) {
-	originalXDG := os.Getenv("XDG_CONFIG_HOME")
-	defer func() {
-		if originalXDG != "" {
-			os.Setenv("XDG_CONFIG_HOME", originalXDG)
-		} else {
-			os.Unsetenv("XDG_CONFIG_HOME")
-		}
-	}()
+func TestConfigSourcesRespectExplicitScopes(t *testing.T) {
+	dir := t.TempDir()
+	global := writeFile(t, dir, "global.gitconfig", "[user]\n")
+	repo := filepath.Join(dir, "repo")
+	local := writeFile(t, repo, ".git/config", "[core]\n")
+	t.Setenv("GIT_CONFIG_GLOBAL", global)
 
-	tempDir, err := os.MkdirTemp("", "test-xdg")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
+	sources := getConfigSources(options{
+		scopes:   []Scope{ScopeLocal},
+		repoPath: repo,
+	})
+	if len(sources) != 1 {
+		t.Fatalf("expected only local source, got %#v", sources)
 	}
-	defer os.RemoveAll(tempDir)
-
-	xdgDir := filepath.Join(tempDir, "git")
-	err = os.MkdirAll(xdgDir, 0755)
-	if err != nil {
-		t.Fatalf("Failed to create XDG git dir: %v", err)
-	}
-
-	configPath := filepath.Join(xdgDir, "config")
-	err = os.WriteFile(configPath, []byte("[test]\n"), 0644)
-	if err != nil {
-		t.Fatalf("Failed to create config file: %v", err)
-	}
-
-	os.Setenv("XDG_CONFIG_HOME", tempDir)
-
-	path := getXDGConfigPath()
-	if path != configPath {
-		t.Errorf("Expected '%s', got '%s'", configPath, path)
+	if sources[0].Scope != ScopeLocal || sources[0].Path != local {
+		t.Fatalf("unexpected source: %#v", sources[0])
 	}
 }
 
-func TestGetHomeConfigPath(t *testing.T) {
-	path := getHomeConfigPath()
-	t.Logf("Home config path: %s", path)
-}
+func TestSystemConfigEnv(t *testing.T) {
+	dir := t.TempDir()
+	system := writeFile(t, dir, "system.gitconfig", "[core]\n")
+	t.Setenv("GIT_CONFIG_SYSTEM", system)
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "")
 
-func TestParseSystemConfigPath(t *testing.T) {
-	tests := []struct {
-		output   string
-		expected string
-	}{
-		{"file:/etc/gitconfig\tcore.editor=vim", "/etc/gitconfig"},
-		{"file:/usr/local/etc/gitconfig\tuser.name=test", "/usr/local/etc/gitconfig"},
-		{"no file prefix", ""},
-		{"", ""},
+	paths := getSystemConfigPaths()
+	if len(paths) != 1 || paths[0] != system {
+		t.Fatalf("unexpected system paths: %#v", paths)
 	}
 
-	for _, test := range tests {
-		result := parseSystemConfigPath(test.output)
-		if result != test.expected {
-			t.Errorf("Expected '%s', got '%s'", test.expected, result)
-		}
+	t.Setenv("GIT_CONFIG_NOSYSTEM", "1")
+	if paths := getSystemConfigPaths(); len(paths) != 0 {
+		t.Fatalf("expected no system paths, got %#v", paths)
 	}
 }
 
-func TestGetSystemConfigPathFallback(t *testing.T) {
-	path := getSystemConfigPathFallback()
-	t.Logf("System config fallback path: %s", path)
+func writeFile(t *testing.T, dir, rel, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
 }

--- a/utils.go
+++ b/utils.go
@@ -1,25 +1,132 @@
 package gitcfg
 
 import (
-    "strings"
+	"fmt"
+	"reflect"
+	"strconv"
+	"strings"
+	"unicode"
 )
 
-func parseConfigKey(key string) (section, keyName string, err error) {
-	parts := strings.SplitN(key, ".", 2)
-	if len(parts) != 2 {
+// Scalar is the set of types supported by Get and GetDefault.
+type Scalar interface {
+	~string | ~int | ~int8 | ~int16 | ~int32 | ~int64 |
+		~uint | ~uint8 | ~uint16 | ~uint32 | ~uint64 |
+		~float32 | ~float64 | ~bool
+}
+
+func normalizeKey(key string) (string, error) {
+	section, name, err := splitConfigKey(key)
+	if err != nil {
+		return "", err
+	}
+	return strings.ToLower(section) + "." + strings.ToLower(name), nil
+}
+
+func splitConfigKey(key string) (section, name string, err error) {
+	key = strings.TrimSpace(key)
+	if key == "" {
 		return "", "", ErrInvalidKeyFormat
 	}
 
-	section, remaining := parts[0], parts[1]
-
-	// remote.origin.url -> section: remote.origin, key: url
-	if strings.Contains(remaining, ".") {
-		subparts := strings.SplitN(remaining, ".", 2)
-		if len(subparts) == 2 {
-			section = section + "." + subparts[0]
-			remaining = subparts[1]
-		}
+	i := strings.LastIndexByte(key, '.')
+	if i <= 0 || i == len(key)-1 {
+		return "", "", ErrInvalidKeyFormat
 	}
 
-	return section, remaining, nil
+	section = strings.TrimSpace(key[:i])
+	name = strings.TrimSpace(key[i+1:])
+	if !isValidSection(section) || !isValidVariableName(name) {
+		return "", "", ErrInvalidKeyFormat
+	}
+
+	return section, name, nil
+}
+
+func isValidSection(section string) bool {
+	if section == "" {
+		return false
+	}
+	for _, r := range section {
+		if r == 0 || r == '\n' || r == '\r' || unicode.IsControl(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func isValidVariableName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, r := range name {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) || r == '-' || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func parseBool(v string) (bool, error) {
+	if v == "" {
+		return true, nil
+	}
+
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "true", "yes", "on", "1":
+		return true, nil
+	case "false", "no", "off", "0":
+		return false, nil
+	default:
+		return false, fmt.Errorf("invalid boolean value: %s", v)
+	}
+}
+
+func convertValue[T Scalar](v string) (T, error) {
+	var zero T
+	typ := reflect.TypeOf(zero)
+	if typ == nil {
+		return zero, fmt.Errorf("%w: unsupported type", ErrInvalidValue)
+	}
+
+	var rv reflect.Value
+	var err error
+
+	switch typ.Kind() {
+	case reflect.String:
+		rv = reflect.ValueOf(v).Convert(typ)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		var n int64
+		n, err = strconv.ParseInt(v, 10, typ.Bits())
+		if err == nil {
+			rv = reflect.ValueOf(n).Convert(typ)
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		var n uint64
+		n, err = strconv.ParseUint(v, 10, typ.Bits())
+		if err == nil {
+			rv = reflect.ValueOf(n).Convert(typ)
+		}
+	case reflect.Float32, reflect.Float64:
+		var n float64
+		n, err = strconv.ParseFloat(v, typ.Bits())
+		if err == nil {
+			rv = reflect.ValueOf(n).Convert(typ)
+		}
+	case reflect.Bool:
+		var b bool
+		b, err = parseBool(v)
+		if err == nil {
+			rv = reflect.ValueOf(b).Convert(typ)
+		}
+	default:
+		err = fmt.Errorf("unsupported type")
+	}
+
+	if err != nil {
+		return zero, fmt.Errorf("%w: %v", ErrInvalidValue, err)
+	}
+
+	return rv.Interface().(T), nil
 }


### PR DESCRIPTION
This prepares `go-gitcfg` for a stable v1 release by rewriting the public API, parser, state model, docs and tests around a smaller and more explicit Git config library surface.

The new implementation uses a pure Go parser by default, preserves repeated keys, tracks source metadata, supports Git precedence, handles includes and common `includeIf` conditions and exposes context-aware loading/reload APIs.

## Changes

- reworked the public API around `Scope`, `Source`, `Entry`, `Config`, `Option` and `Scalar`.
- made loading context-first with `Load(ctx, ...)`, `LoadGlobal(ctx)`, `LoadLocal(ctx, repo)` and `LoadAll(ctx, repo)`.
- replaced scope-specific option helpers with `WithScopes(...)`.
- added atomic snapshot-based `Config` state with safe clone/reload.
- added raw entry preservation through `Entries` and repeated value access through `Values`.
- rewrote Git config parsing for sections, subsections, quoted values, inline comments, continuations, bare boolean values, includes, include cycles and conditional includes.
- added optional `git config --list --show-origin` loading via `WithGitCommand`.
- reworked path discovery for system, global, local, worktree, XDG, env overrides and `.git` file repositories.
- updated tests.

## Breaking

- `Load`, `LoadGlobal`, `LoadLocal`, and `LoadAll` now require `context.Context`.
- `LoadWithContext` and `ReloadWithContext` are replaced by context-first APIs.
- `Config.Reload()` is now `Config.Reload(ctx)`.
- `ConfigOption` is now `Option`.
- `WithSystem`, `WithGlobal`, `WithLocal` and `WithWorktree` are replaced by `WithScopes`.
- `ConfigSourceType`/`ConfigSource` are replaced by `Scope`/`Source`.
- `Constraint` is now `Scalar`.
- `GetWithDefault` is now `GetDefault`.
- accessors were renamed for a smaller API: `GetUser` -> `User`, `GetRemoteURL` -> `RemoteURL`, `GetSection` -> `Section`, `GetSections` -> `Sections`, `GetAll` -> `All`, `GetSources` -> `Sources`.